### PR TITLE
[정진호] week3

### DIFF
--- a/asset/styles/component.css
+++ b/asset/styles/component.css
@@ -82,27 +82,3 @@ h2 {
     line-height: normal;
     border-bottom: 0.1rem solid var(--primary);
 }
-
-@media (max-width: 1199px) and (min-width: 768px) {
-    
-}
-    
-@media (max-width: 767px) and (min-width: 375px) {
-    .logo--regular {
-        width: 8.9rem;
-        height: 1.6rem;
-    }
-
-    .btn {
-        padding: 10px 16px;
-        font-size: 1.4rem;
-    }
-
-    .btn--width-128 {
-        width: 80px;
-    }
-
-    .btn--width-350 {
-        width: 200px;
-    }
-}

--- a/asset/styles/component.css
+++ b/asset/styles/component.css
@@ -40,6 +40,12 @@ h2 {
     background-size: cover;
 }
 
+.logo > a {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
 .btn {
     background: linear-gradient(91deg, var(--primary) 0.12%, #6AE3FE 101.84%);
     display: block;

--- a/asset/styles/component.css
+++ b/asset/styles/component.css
@@ -17,7 +17,7 @@ h2 {
 
 :root {
     --primary: #6D6AFE;
-    --red: #FF5B56;
+    --error: #FF5B56;
     --black: #111322;
     --white: #ffffff;
     --gray5: #373740;
@@ -40,37 +40,20 @@ h2 {
     background-size: cover;
 }
 
-.logo--regular {
-    width: 13.3rem;
-    height: 2.4rem;
-}
-
 .logo--large {
     width: 21rem;
     height: 3.8rem;
 }
 
 .btn {
-    background: linear-gradient(91deg, #6D6AFE 0.12%, #6AE3FE 101.84%);
+    background: linear-gradient(91deg, var(--primary) 0.12%, #6AE3FE 101.84%);
     display: block;
     color: #F5F5F5;
-    border-radius: 0.8rem;
     padding: 1.6rem 2.0rem;
     font-size: 1.8rem;
+    border-radius: 0.8rem;
     font-weight: 600;
     text-align: center;
-}
-
-.btn--width-128 {
-    width: 12.8rem;
-}
-
-.btn--width-350 {
-    width: 35rem;
-}
-
-.btn--width-full {
-    width: 100%;
 }
 
 .text--link {

--- a/asset/styles/component.css
+++ b/asset/styles/component.css
@@ -40,11 +40,6 @@ h2 {
     background-size: cover;
 }
 
-.logo--large {
-    width: 21rem;
-    height: 3.8rem;
-}
-
 .btn {
     background: linear-gradient(91deg, var(--primary) 0.12%, #6AE3FE 101.84%);
     display: block;

--- a/asset/styles/component.css
+++ b/asset/styles/component.css
@@ -96,10 +96,13 @@ h2 {
     .btn {
         padding: 10px 16px;
         font-size: 1.4rem;
-        
     }
 
     .btn--width-128 {
         width: 80px;
+    }
+
+    .btn--width-350 {
+        width: 200px;
     }
 }

--- a/asset/styles/component.css
+++ b/asset/styles/component.css
@@ -82,3 +82,24 @@ h2 {
     line-height: normal;
     border-bottom: 0.1rem solid var(--primary);
 }
+
+@media (max-width: 1199px) and (min-width: 768px) {
+    
+}
+    
+@media (max-width: 767px) and (min-width: 375px) {
+    .logo--regular {
+        width: 8.9rem;
+        height: 1.6rem;
+    }
+
+    .btn {
+        padding: 10px 16px;
+        font-size: 1.4rem;
+        
+    }
+
+    .btn--width-128 {
+        width: 80px;
+    }
+}

--- a/asset/styles/index.css
+++ b/asset/styles/index.css
@@ -1,7 +1,8 @@
 .header {
     position: fixed;
     top: 0;
-    width: 100%;
+    left: 0;
+    right: 0;
     padding: 2.0rem 20.0rem;
     backdrop-filter: blur(5px);
     -webkit-backdrop-filter: blur(5px);
@@ -148,3 +149,24 @@
     justify-content: center;
     gap: 1.2rem;
 }
+
+
+
+@media (max-width: 1199px) and (min-width: 768px) {
+    .header {
+        padding: 2.0rem 3.2rem;
+        margin: 0 auto;
+        max-width: 86.4rem;
+
+    }
+}
+    
+@media (max-width: 767px) and (min-width: 375px) {
+    .header {
+        padding: 1.3rem 3.2rem;
+    }
+}
+
+
+
+

--- a/asset/styles/index.css
+++ b/asset/styles/index.css
@@ -11,6 +11,10 @@
     justify-content: space-between;
 }
 
+.nav__btn {
+    width: 12.8rem;
+}
+
 .hero_sec {
     background-color: var(--gray1);
 }
@@ -32,6 +36,10 @@
     font-size: 6.4rem;
     font-weight: 700;
     line-height: 8.0rem;
+}
+
+.hero_sec__btn {
+    width: 35rem;
 }
 
 .hero_sec__title .text--gradiant {
@@ -162,7 +170,7 @@
     gap: 1.2rem;
 }
 
-@media (max-width: 1199px) and (min-width: 768px) {
+@media (max-width: 1199px) {
     .nav {
         padding: 2.0rem 3.2rem;
         margin: 0 auto;
@@ -204,27 +212,23 @@
     }
 }
     
-@media (max-width: 767px) and (min-width: 375px) {
+@media (max-width: 767px) {
     .logo--regular {
         width: 8.9rem;
         height: 1.6rem;
     }
 
     .btn {
-        padding: 10px 16px;
+        padding: 1rem 1.6rem;
         font-size: 1.4rem;
-    }
-
-    .btn--width-128 {
-        width: 80px;
-    }
-
-    .btn--width-350 {
-        width: 200px;
     }
 
     .nav {
         padding: 1.3rem 3.2rem;
+    }
+
+    .nav__btn {
+        width: 8rem;
     }
 
     .hero_sec__container {
@@ -234,6 +238,10 @@
     .hero_sec__title {
         font-size: 3.2rem;
         line-height: 4.2rem;
+    }
+
+    .hero_sec__btn {
+        width: 20rem;
     }
 
     .hero_sec__img {

--- a/asset/styles/index.css
+++ b/asset/styles/index.css
@@ -57,23 +57,35 @@
     width: 100%;
     margin: 0 auto;
     padding: 12.0rem 0 5.0rem 0;
-    display: flex;
-    align-items: center;
+    display: grid;
     justify-content: center;
-    gap: 15.7rem;
+    gap: 1rem 15.7rem;
 }
 
-.service_explain__container {
-    width: 29.1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1.0rem;
-}
+.service_explain:nth-of-type(odd) {
+    grid-template:
+      ". img"
+      "t img"
+      "s img"
+      ". img"
+      /29.1rem 55rem;
+  }
+  
+.service_explain:nth-of-type(even) {
+    grid-template:
+      "img ."
+      "img t"
+      "img s"
+      "img ."
+      /55rem 29.1rem;
+  }
+  
 
 .service_explain__title {
     font-size: 4.8rem;
     font-weight: 700;
     letter-spacing: -0.03rem;
+    grid-area: t;
 }
 
 .service_explain__subtitle {
@@ -81,6 +93,7 @@
     font-size: 1.6rem;
     font-weight: 500;
     line-height: 150%;
+    grid-area: s;
 }
 
 .service_explain__img {
@@ -88,6 +101,7 @@
     height: 45rem;
     border-radius: 1.5rem;
     background-color: var(--gray1);
+    grid-area: img;
 }
 
 #manage_your_link,

--- a/asset/styles/index.css
+++ b/asset/styles/index.css
@@ -1,9 +1,7 @@
 .header {
     position: fixed;
     top: 0;
-    max-width: 192rem;
     width: 100%;
-    margin: 0 auto;
     padding: 2.0rem 20.0rem;
     backdrop-filter: blur(5px);
     -webkit-backdrop-filter: blur(5px);

--- a/asset/styles/index.css
+++ b/asset/styles/index.css
@@ -160,11 +160,29 @@
         width: 65rem;
         height: 31.3rem;
     }
+
+    .service_explain {
+        padding-top: 8rem;
+        gap: 5.1rem;
+    }
+
+    .service_explain__container {
+        width: 26.2rem;
+    }
+
+    .service_explain__img {
+        width: 38.5rem;
+        height: 31.5rem;
+    }
 }
     
 @media (max-width: 767px) and (min-width: 375px) {
     .header {
         padding: 1.3rem 3.2rem;
+    }
+
+    .hero_sec__container {
+        padding-top: 9rem;
     }
 
     .hero_sec__title {
@@ -175,6 +193,48 @@
     .hero_sec__img {
         width: 30.2rem;
         height: 14.6rem;
+    }
+
+    .service_explain {
+        flex-direction: column;
+        padding: 4rem 3.3rem 4.2rem;
+        gap: 2.4rem;
+    }
+
+    .service_explain__container {
+        width: 100%;
+    }
+
+    .service_explain__title {
+        font-size: 2.4rem;
+    }
+
+    .service_explain__subtitle {
+        font-size: 1.5rem;
+    }
+
+    .service_explain__img {
+        width: 100%;
+        height: auto;
+    }
+
+    #manage_your_link,
+    #search_your_link {
+    flex-direction: column;
+    }
+
+    .footer {
+        padding-top: 4rem;
+    }
+
+    .footer__container {
+        position: relative;
+        padding: 3.2rem 3.2rem 6.4rem;
+    }
+
+    .footer__copyright {
+        position: absolute;
+        bottom: 3.2rem;
     }
 }
 

--- a/asset/styles/index.css
+++ b/asset/styles/index.css
@@ -177,6 +177,24 @@
 }
     
 @media (max-width: 767px) and (min-width: 375px) {
+    .logo--regular {
+        width: 8.9rem;
+        height: 1.6rem;
+    }
+
+    .btn {
+        padding: 10px 16px;
+        font-size: 1.4rem;
+    }
+
+    .btn--width-128 {
+        width: 80px;
+    }
+
+    .btn--width-350 {
+        width: 200px;
+    }
+
     .header {
         padding: 1.3rem 3.2rem;
     }

--- a/asset/styles/index.css
+++ b/asset/styles/index.css
@@ -290,7 +290,6 @@
         "priv social"
         "copy .";
         justify-content: space-between;
-        height: 15rem;
         padding: 3.2rem;
     }
 

--- a/asset/styles/index.css
+++ b/asset/styles/index.css
@@ -53,8 +53,7 @@
 }
 
 .service_explain {
-    max-width: 192rem;
-    width: 100%;
+    width: 99.8rem;
     margin: 0 auto;
     padding: 12.0rem 0 5.0rem 0;
     display: grid;
@@ -62,7 +61,7 @@
     gap: 1rem 15.7rem;
 }
 
-.service_explain:nth-of-type(odd) {
+.service_explain--odd {
     grid-template:
       ". img"
       "t img"
@@ -71,7 +70,7 @@
       /29.1rem 55rem;
   }
   
-.service_explain:nth-of-type(even) {
+.service_explain--even {
     grid-template:
       "img ."
       "img t"
@@ -164,7 +163,7 @@
 }
 
 @media (max-width: 1199px) and (min-width: 768px) {
-    .header {
+    .nav {
         padding: 2.0rem 3.2rem;
         margin: 0 auto;
         max-width: 86.4rem;
@@ -176,13 +175,28 @@
     }
 
     .service_explain {
+        width: 69.8rem;
         padding-top: 8rem;
-        gap: 5.1rem;
+        gap: 1rem 5.1rem;
     }
 
-    .service_explain__container {
-        width: 26.2rem;
-    }
+    .service_explain--odd {
+        grid-template:
+          ". img"
+          "t img"
+          "s img"
+          ". img"
+          /26.2rem 38.5rem;
+      }
+      
+    .service_explain--even {
+        grid-template:
+          "img ."
+          "img t"
+          "img s"
+          "img ."
+          /38.5rem 26.2rem;
+      }
 
     .service_explain__img {
         width: 38.5rem;
@@ -209,7 +223,7 @@
         width: 200px;
     }
 
-    .header {
+    .nav {
         padding: 1.3rem 3.2rem;
     }
 
@@ -226,16 +240,19 @@
         width: 30.2rem;
         height: 14.6rem;
     }
-
-    .service_explain {
-        flex-direction: column;
-        padding: 4rem 3.3rem 4.2rem;
-        gap: 2.4rem;
-    }
-
-    .service_explain__container {
+    
+    .service_explain--odd,
+    .service_explain--even {
         width: 100%;
-    }
+        margin: 0;
+        padding: 4rem 3.2rem 3.6rem;
+        grid-template:
+          "t"
+          "img"
+          "img"
+          "s";
+          gap: 2rem;
+      }
 
     .service_explain__title {
         font-size: 2.4rem;

--- a/asset/styles/index.css
+++ b/asset/styles/index.css
@@ -73,7 +73,7 @@
 .service_explain__title {
     font-size: 4.8rem;
     font-weight: 700;
-    letter-spacing: -0.3rem;
+    letter-spacing: -0.03rem;
 }
 
 .service_explain__subtitle {

--- a/asset/styles/index.css
+++ b/asset/styles/index.css
@@ -11,6 +11,11 @@
     justify-content: space-between;
 }
 
+.nav__logo {
+    width: 13.3rem;
+    height: 2.4rem;
+}
+
 .nav__btn {
     width: 12.8rem;
 }
@@ -140,7 +145,10 @@
 
 .footer__container {
     width: 100%;
-    display: flex;
+    display: grid;
+    grid-template:
+    "copy priv social"
+    / auto auto auto;
     justify-content: space-between;
     height: 16.0rem;
     padding: 3.2rem 10.4rem 6.4rem 10.4rem;
@@ -150,6 +158,7 @@
 .footer__copyright {
     color: #676767;
     font-size: 1.6rem;
+    grid-area: copy;
 }
 
 .footer__privacy {
@@ -157,6 +166,7 @@
     font-size: 1.6rem;
     display: flex;
     justify-content: center;
+    grid-area: priv;
 }
 
 .footer__privacy a {
@@ -168,6 +178,7 @@
     display: flex;
     justify-content: center;
     gap: 1.2rem;
+    grid-area: social;
 }
 
 @media (max-width: 1199px) {
@@ -189,21 +200,11 @@
     }
 
     .service_explain--odd {
-        grid-template:
-          ". img"
-          "t img"
-          "s img"
-          ". img"
-          /26.2rem 38.5rem;
+        grid-template-columns: 26.2rem 38.5rem;
       }
       
     .service_explain--even {
-        grid-template:
-          "img ."
-          "img t"
-          "img s"
-          "img ."
-          /38.5rem 26.2rem;
+        grid-template-columns: 38.5rem 26.2rem;
       }
 
     .service_explain__img {
@@ -213,7 +214,7 @@
 }
     
 @media (max-width: 767px) {
-    .logo--regular {
+    .nav__logo {
         width: 8.9rem;
         height: 1.6rem;
     }
@@ -285,13 +286,17 @@
     }
 
     .footer__container {
-        position: relative;
-        padding: 3.2rem 3.2rem 6.4rem;
+        grid-template:
+        "priv social"
+        "copy .";
+        justify-content: space-between;
+        height: 15rem;
+        padding: 3.2rem;
     }
 
     .footer__copyright {
-        position: absolute;
-        bottom: 3.2rem;
+        justify-self: start;
+        align-self: end;
     }
 }
 

--- a/asset/styles/index.css
+++ b/asset/styles/index.css
@@ -40,8 +40,7 @@
 
 .hero_sec__img {
     flex-shrink: 0;
-    max-width: 111.8rem;
-    width: 100%;
+    width: 111.8rem;
     height: 53.9rem;
     margin: 0 auto;
     border-radius: 2.5rem 2.5rem 0 0;
@@ -150,20 +149,32 @@
     gap: 1.2rem;
 }
 
-
-
 @media (max-width: 1199px) and (min-width: 768px) {
     .header {
         padding: 2.0rem 3.2rem;
         margin: 0 auto;
         max-width: 86.4rem;
+    }
 
+    .hero_sec__img {
+        width: 65rem;
+        height: 31.3rem;
     }
 }
     
 @media (max-width: 767px) and (min-width: 375px) {
     .header {
         padding: 1.3rem 3.2rem;
+    }
+
+    .hero_sec__title {
+        font-size: 3.2rem;
+        line-height: 4.2rem;
+    }
+
+    .hero_sec__img {
+        width: 30.2rem;
+        height: 14.6rem;
     }
 }
 

--- a/asset/styles/index.css
+++ b/asset/styles/index.css
@@ -298,7 +298,3 @@
         align-self: end;
     }
 }
-
-
-
-

--- a/asset/styles/index.css
+++ b/asset/styles/index.css
@@ -1,4 +1,4 @@
-.header {
+.nav {
     position: fixed;
     top: 0;
     left: 0;

--- a/asset/styles/sign.css
+++ b/asset/styles/sign.css
@@ -19,6 +19,11 @@ html {
     gap: 1.6rem;
 }
 
+.header__logo {
+    width: 21rem;
+    height: 3.8rem;
+}
+
 .header__subtitle {
     gap: 0.8rem;
     font-size: 1.6rem;

--- a/asset/styles/sign.css
+++ b/asset/styles/sign.css
@@ -2,11 +2,12 @@ html {
     background-color: #F0F6FF;
 }
 
-body {
-    max-width: 40rem;
+.main {
+    max-width: 46.4rem;
     width: 100%;
-    margin: 23.8rem auto 0;
+    padding: 0 3.2rem;
     display: flex;
+    margin: 23.8rem auto 0;
     flex-direction: column;
     align-items: center;
 }
@@ -25,7 +26,7 @@ body {
     align-items: flex-start;
 }
 
-.main {
+.sign {
     width: 100%;
     margin-top: 3rem
 }
@@ -93,6 +94,7 @@ body {
 
 .form__btn {
     margin-top: 0.6rem;
+    width: 100%;
 }
 
 .footer {
@@ -122,15 +124,14 @@ body {
     width: 4.2rem;
 }
 
-@media (max-width: 1199px) and (min-width: 768px) {
-    body {
+@media (max-width: 1191px) {
+    .main {
         margin-top: 20rem;
     }
 }
 
-@media (max-width: 767px) and (min-width: 375px) {
-    body {
+@media (max-width: 767px) {
+    .main {
         margin-top: 12rem;
-        width: 85%;
     }
 }

--- a/asset/styles/sign.css
+++ b/asset/styles/sign.css
@@ -62,7 +62,7 @@ body {
 }
 
 .form__input:focus-within {
-    border: 0.1rem solid var(--primary)
+    border: 0.1rem solid var(--primary);
 }
 
 .input__container {

--- a/asset/styles/sign.css
+++ b/asset/styles/sign.css
@@ -3,7 +3,8 @@ html {
 }
 
 body {
-    width: 40rem;
+    max-width: 40rem;
+    width: 100%;
     margin: 23.8rem auto 0;
     display: flex;
     flex-direction: column;
@@ -119,4 +120,17 @@ body {
 
 .footer__icon a {
     width: 4.2rem;
+}
+
+@media (max-width: 1199px) and (min-width: 768px) {
+    body {
+        margin-top: 20rem;
+    }
+}
+
+@media (max-width: 767px) and (min-width: 375px) {
+    body {
+        margin-top: 12rem;
+        width: 85%;
+    }
 }

--- a/index.html
+++ b/index.html
@@ -17,10 +17,10 @@
 </head>
 
 <body>
-    <header class="header">
+    <nav class="header">
         <h1 class="logo logo--regular"><a href="/" title="Linkbrary의 로고"></a></h1>
         <a class="btn btn--width-128" href="/signin.html" title="signin">로그인</a>
-    </header>
+    </nav>
 
     <main>
         <section class="hero_sec">

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 
 <body>
     <nav class="nav">
-        <h1 class="logo logo--regular"><a href="/" title="Linkbrary의 로고"></a></h1>
+        <h1 class="nav__logo logo"><a href="/" title="Linkbrary의 로고"></a></h1>
         <a class="nav__btn btn" href="/signin.html" title="signin">로그인</a>
     </nav>
 

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 <body>
     <nav class="nav">
         <h1 class="logo logo--regular"><a href="/" title="Linkbrary의 로고"></a></h1>
-        <a class="btn btn--width-128" href="/signin.html" title="signin">로그인</a>
+        <a class="nav__btn btn" href="/signin.html" title="signin">로그인</a>
     </nav>
 
     <header class="hero_sec">
@@ -27,7 +27,7 @@
             <h2 class="hero_sec__title"><span class="text--gradiant">세상의 모든 정보</span>를<br />
                 쉽게 저장하고 관리해 보세요</h2>
 
-            <a class="btn btn--width-350" href="/signup.html" title="signup">링크 추가하기</a>
+            <a class="hero_sec__btn btn" href="/signup.html" title="signup">링크 추가하기</a>
 
             <div class="hero_sec__img"></div>
         </div>
@@ -47,13 +47,13 @@
         </section>
 
         <section class="service_explain service_explain--odd" id="share_your_link">
-            <h2 class="service_explain__title">저장한 링크를 <span class="text--gradiant">공유</span>해 보세요.</h2>
+            <h2 class="service_explain__title">저장한 링크를 <span class="text--gradiant">공유</span>해 보세요</h2>
             <p class="service_explain__subtitle">여러 링크를 폴더에 담고 공유할 수 있습니다. 가족, 친구, 동료들에게 쉽고 빠르게 링크를 공유해 보세요.</p>
             <div class="service_explain__img"><img src="/asset/images/share_your_link.png" alt="" /></div>
         </section>
 
         <section class="service_explain service_explain--even" id="search_your_link">
-            <h2 class="service_explain__title">저장한 링크를 <span class="text--gradiant">검색</span>해 보세요.</h2>
+            <h2 class="service_explain__title">저장한 링크를 <span class="text--gradiant">검색</span>해 보세요</h2>
             <p class="service_explain__subtitle">중요한 정보들을 검색으로 쉽게 찾아보세요.</p>
             <div class="service_explain__img"><img src="/asset/images/search_your_link.png" alt="" />
         </section>

--- a/index.html
+++ b/index.html
@@ -36,38 +36,26 @@
 
     <main>
         <section class="service_explain" id="save_your_link">
-            <div class="service_explain__container">
-                <h2 class="service_explain__title"><span class="text--gradiant">원하는 링크</span>를 저장하세요</h2>
-                <p class="service_explain__subtitle">나중에 읽고 싶은 글, 다시 보고 싶은 영상, 사고 싶은 옷, 기억하고 싶은 모든 것을 한 공간에 저장하세요.</p>
-            </div>
-
+            <h2 class="service_explain__title"><span class="text--gradiant">원하는 링크</span>를 저장하세요</h2>
+            <p class="service_explain__subtitle">나중에 읽고 싶은 글, 다시 보고 싶은 영상, 사고 싶은 옷, 기억하고 싶은 모든 것을 한 공간에 저장하세요.</p>
             <div class="service_explain__img"><img src="/asset/images/save_your_link.png" alt="" /></div>
         </section>
 
         <section class="service_explain" id="manage_your_link">
-            <div class="service_explain__container">
-                <h2 class="service_explain__title">링크를 폴더로 <span class="text--gradiant">관리</span>하세요</h2>
-                <p class="service_explain__subtitle">나만의 폴더를 무제한으로 만들고 다양하게 활용할 수 있습니다.</p>
-            </div>
-
+            <h2 class="service_explain__title">링크를 폴더로 <span class="text--gradiant">관리</span>하세요</h2>
+            <p class="service_explain__subtitle">나만의 폴더를 무제한으로 만들고 다양하게 활용할 수 있습니다.</p>
             <div class="service_explain__img"><img src="/asset/images/manage_your_link.png" alt="" /></div>
         </section>
 
         <section class="service_explain" id="share_your_link">
-            <div class="service_explain__container">
-                <h2 class="service_explain__title">저장한 링크를 <span class="text--gradiant">공유</span>해 보세요.</h2>
-                <p class="service_explain__subtitle">여러 링크를 폴더에 담고 공유할 수 있습니다. 가족, 친구, 동료들에게 쉽고 빠르게 링크를 공유해 보세요.</p>
-            </div>
-
+            <h2 class="service_explain__title">저장한 링크를 <span class="text--gradiant">공유</span>해 보세요.</h2>
+            <p class="service_explain__subtitle">여러 링크를 폴더에 담고 공유할 수 있습니다. 가족, 친구, 동료들에게 쉽고 빠르게 링크를 공유해 보세요.</p>
             <div class="service_explain__img"><img src="/asset/images/share_your_link.png" alt="" /></div>
         </section>
 
         <section class="service_explain" id="search_your_link">
-            <div class="service_explain__container">
-                <h2 class="service_explain__title">저장한 링크를 <span class="text--gradiant">검색</span>해 보세요.</h2>
-                <p class="service_explain__subtitle">중요한 정보들을 검색으로 쉽게 찾아보세요.</p>
-            </div>
-
+            <h2 class="service_explain__title">저장한 링크를 <span class="text--gradiant">검색</span>해 보세요.</h2>
+            <p class="service_explain__subtitle">중요한 정보들을 검색으로 쉽게 찾아보세요.</p>
             <div class="service_explain__img"><img src="/asset/images/search_your_link.png" alt="" />
         </section>
     </main>

--- a/index.html
+++ b/index.html
@@ -22,18 +22,19 @@
         <a class="btn btn--width-128" href="/signin.html" title="signin">로그인</a>
     </nav>
 
+
+    <header class="hero_sec">
+        <div class="hero_sec__container">
+            <h2 class="hero_sec__title"><span class="text--gradiant">세상의 모든 정보</span>를<br />
+                쉽게 저장하고 관리해 보세요</h2>
+
+            <a class="btn btn--width-350" href="/signup.html" title="signup">링크 추가하기</a>
+
+            <div class="hero_sec__img"></div>
+        </div>
+    </header>
+
     <main>
-        <section class="hero_sec">
-            <div class="hero_sec__container">
-                <h2 class="hero_sec__title"><span class="text--gradiant">세상의 모든 정보</span>를<br />
-                    쉽게 저장하고 관리해 보세요</h2>
-
-                <a class="btn btn--width-350" href="/signup.html" title="signup">링크 추가하기</a>
-
-                <div class="hero_sec__img"></div>
-            </div>
-        </section>
-
         <section class="service_explain" id="save_your_link">
             <div class="service_explain__container">
                 <h2 class="service_explain__title"><span class="text--gradiant">원하는 링크</span>를 저장하세요</h2>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
     <link rel="stylesheet" href="/asset/styles/component.css">
     <link rel="stylesheet" href="/asset/styles/index.css">
     <link rel="stylesheet" href="/asset/pretendard/pretendard.css">
+    <meta property="og:title" content="Linkbrary" />
+    <meta property="og:description" content="세상의 모든 정보를 쉽게 저장하고 관리해 보세요">
+    <meta property="og:url" content="https://codeitweeklymission.netlify.app/" />
+    <meta property="og:image" content="/asset/images/hero_sec.png" />
+
     <title>Linkbrary</title>
 </head>
 

--- a/index.html
+++ b/index.html
@@ -17,11 +17,10 @@
 </head>
 
 <body>
-    <nav class="header">
+    <nav class="nav">
         <h1 class="logo logo--regular"><a href="/" title="Linkbrary의 로고"></a></h1>
         <a class="btn btn--width-128" href="/signin.html" title="signin">로그인</a>
     </nav>
-
 
     <header class="hero_sec">
         <div class="hero_sec__container">
@@ -35,25 +34,25 @@
     </header>
 
     <main>
-        <section class="service_explain" id="save_your_link">
+        <section class="service_explain service_explain--odd" id="save_your_link">
             <h2 class="service_explain__title"><span class="text--gradiant">원하는 링크</span>를 저장하세요</h2>
             <p class="service_explain__subtitle">나중에 읽고 싶은 글, 다시 보고 싶은 영상, 사고 싶은 옷, 기억하고 싶은 모든 것을 한 공간에 저장하세요.</p>
             <div class="service_explain__img"><img src="/asset/images/save_your_link.png" alt="" /></div>
         </section>
 
-        <section class="service_explain" id="manage_your_link">
+        <section class="service_explain service_explain--even" id="manage_your_link">
             <h2 class="service_explain__title">링크를 폴더로 <span class="text--gradiant">관리</span>하세요</h2>
             <p class="service_explain__subtitle">나만의 폴더를 무제한으로 만들고 다양하게 활용할 수 있습니다.</p>
             <div class="service_explain__img"><img src="/asset/images/manage_your_link.png" alt="" /></div>
         </section>
 
-        <section class="service_explain" id="share_your_link">
+        <section class="service_explain service_explain--odd" id="share_your_link">
             <h2 class="service_explain__title">저장한 링크를 <span class="text--gradiant">공유</span>해 보세요.</h2>
             <p class="service_explain__subtitle">여러 링크를 폴더에 담고 공유할 수 있습니다. 가족, 친구, 동료들에게 쉽고 빠르게 링크를 공유해 보세요.</p>
             <div class="service_explain__img"><img src="/asset/images/share_your_link.png" alt="" /></div>
         </section>
 
-        <section class="service_explain" id="search_your_link">
+        <section class="service_explain service_explain--even" id="search_your_link">
             <h2 class="service_explain__title">저장한 링크를 <span class="text--gradiant">검색</span>해 보세요.</h2>
             <p class="service_explain__subtitle">중요한 정보들을 검색으로 쉽게 찾아보세요.</p>
             <div class="service_explain__img"><img src="/asset/images/search_your_link.png" alt="" />

--- a/signin.html
+++ b/signin.html
@@ -14,7 +14,7 @@
 <body>
         <main class="main">
             <header class="header">
-                <h1 class="logo logo--large"><a href="/" title="Linkbrary의 로고"></a></h1>
+                <h1 class="header__logo logo"><a href="/" title="Linkbrary의 로고"></a></h1>
 
                 <div class="header__subtitle">
                     <p>회원이 아니신가요?</p>

--- a/signin.html
+++ b/signin.html
@@ -12,42 +12,45 @@
 </head>
 
 <body>
-    <header class="header">
-        <h1 class="logo logo--large"><a href="/" title="Linkbrary의 로고"></a></h1>
+        <main class="main">
+            <header class="header">
+                <h1 class="logo logo--large"><a href="/" title="Linkbrary의 로고"></a></h1>
 
-        <div class="header__subtitle">
-            <p>회원이 아니신가요?</p>
-            <a class="text--link" href="/signup.html" title="signup">회원 가입하기</a>
-        </div>
-    </header>
-
-    <main class="main">
-        <form class="form">
-            <div class="form__container">
-                <label class="form__label" for="signinEmail">이메일</label>
-                <div class="form__input">
-                    <input class="input__container" id="signinEmail" name="email" type="email">
+                <div class="header__subtitle">
+                    <p>회원이 아니신가요?</p>
+                    <a class="text--link" href="/signup.html" title="signup">회원 가입하기</a>
                 </div>
-            </div>
+            </header>
 
-            <div class="form__container">
-                <label class="form__label" for="signinPassword">비밀번호</label>
-                <div class="form__input">
-                    <input class="input__container" id="signinPassword" name="password" type="password">
-                    <button class="input__eyes input__eyes--off" type="button"></button>
+            <section class="sign">
+                <form class="form">
+                    <div class="form__container">
+                        <label class="form__label" for="signinEmail">이메일</label>
+                        <div class="form__input">
+                            <input class="input__container" id="signinEmail" name="email" type="email">
+                        </div>
+                    </div>
+
+                    <div class="form__container">
+                        <label class="form__label" for="signinPassword">비밀번호</label>
+                        <div class="form__input">
+                            <input class="input__container" id="signinPassword" name="password" type="password">
+                            <button class="input__eyes input__eyes--off" type="button"></button>
+                        </div>
+                    </div>
+
+                    <button class="form__btn btn">로그인</button>
+                </form>
+            </section>
+
+            <footer class="footer">
+                <p class="footer__title">소셜 로그인</p>
+                <div class="footer__icon">
+                    <a href="https://www.google.com/" target="_blank"><img src="/asset/images/sign_google.png" alt="구글 로그인 아이콘" /></a>
+                    <a href="https://www.kakaocorp.com/page/" target="_blank"><img src="/asset/images/sign_kakao.png" alt="카카오톡 로그인 아이콘" /></a>
                 </div>
-            </div>
+            </footer>
+        </main>
 
-            <button class="form__btn btn btn--width-full">로그인</button>
-        </form>
-    </main>
-
-    <footer class="footer">
-        <p class="footer__title">소셜 로그인</p>
-        <div class="footer__icon">
-            <a href="https://www.google.com/" target="_blank"><img src="/asset/images/sign_google.png" alt="구글 로그인 아이콘" /></a>
-            <a href="https://www.kakaocorp.com/page/" target="_blank"><img src="/asset/images/sign_kakao.png" alt="카카오톡 로그인 아이콘" /></a>
-        </div>
-    </footer>
 </body>
 </html>

--- a/signin.html
+++ b/signin.html
@@ -12,45 +12,44 @@
 </head>
 
 <body>
-        <main class="main">
-            <header class="header">
-                <h1 class="header__logo logo"><a href="/" title="Linkbrary의 로고"></a></h1>
+    <main class="main">
+        <header class="header">
+            <h1 class="header__logo logo"><a href="/" title="Linkbrary의 로고"></a></h1>
 
-                <div class="header__subtitle">
-                    <p>회원이 아니신가요?</p>
-                    <a class="text--link" href="/signup.html" title="signup">회원 가입하기</a>
-                </div>
-            </header>
+            <div class="header__subtitle">
+                <p>회원이 아니신가요?</p>
+                <a class="text--link" href="/signup.html" title="signup">회원 가입하기</a>
+            </div>
+        </header>
 
-            <section class="sign">
-                <form class="form">
-                    <div class="form__container">
-                        <label class="form__label" for="signinEmail">이메일</label>
-                        <div class="form__input">
-                            <input class="input__container" id="signinEmail" name="email" type="email">
-                        </div>
+        <section class="sign">
+            <form class="form">
+                <div class="form__container">
+                    <label class="form__label" for="signinEmail">이메일</label>
+                    <div class="form__input">
+                        <input class="input__container" id="signinEmail" name="email" type="email">
                     </div>
-
-                    <div class="form__container">
-                        <label class="form__label" for="signinPassword">비밀번호</label>
-                        <div class="form__input">
-                            <input class="input__container" id="signinPassword" name="password" type="password">
-                            <button class="input__eyes input__eyes--off" type="button"></button>
-                        </div>
-                    </div>
-
-                    <button class="form__btn btn">로그인</button>
-                </form>
-            </section>
-
-            <footer class="footer">
-                <p class="footer__title">소셜 로그인</p>
-                <div class="footer__icon">
-                    <a href="https://www.google.com/" target="_blank"><img src="/asset/images/sign_google.png" alt="구글 로그인 아이콘" /></a>
-                    <a href="https://www.kakaocorp.com/page/" target="_blank"><img src="/asset/images/sign_kakao.png" alt="카카오톡 로그인 아이콘" /></a>
                 </div>
-            </footer>
-        </main>
 
+                <div class="form__container">
+                    <label class="form__label" for="signinPassword">비밀번호</label>
+                    <div class="form__input">
+                        <input class="input__container" id="signinPassword" name="password" type="password">
+                        <button class="input__eyes input__eyes--off" type="button"></button>
+                    </div>
+                </div>
+
+                <button class="form__btn btn">로그인</button>
+            </form>
+        </section>
+
+        <footer class="footer">
+            <p class="footer__title">소셜 로그인</p>
+            <div class="footer__icon">
+                <a href="https://www.google.com/" target="_blank"><img src="/asset/images/sign_google.png" alt="구글 로그인 아이콘" /></a>
+                <a href="https://www.kakaocorp.com/page/" target="_blank"><img src="/asset/images/sign_kakao.png" alt="카카오톡 로그인 아이콘" /></a>
+            </div>
+        </footer>
+    </main>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -15,7 +15,7 @@
     <div class="center_container">
         <main class="main">
             <header class="header">
-                <h1 class="logo logo--large"><a href="/" title="Linkbrary의 로고"></a></h1>
+                <h1 class="header__logo logo"><a href="/" title="Linkbrary의 로고"></a></h1>
 
                 <div class="header__subtitle">
                     <p>이미 회원이신가요?</p>

--- a/signup.html
+++ b/signup.html
@@ -12,54 +12,52 @@
 </head>
 
 <body>
-    <div class="center_container">
-        <main class="main">
-            <header class="header">
-                <h1 class="header__logo logo"><a href="/" title="Linkbrary의 로고"></a></h1>
+    <main class="main">
+        <header class="header">
+            <h1 class="header__logo logo"><a href="/" title="Linkbrary의 로고"></a></h1>
 
-                <div class="header__subtitle">
-                    <p>이미 회원이신가요?</p>
-                    <a class="text--link" href="/signin.html" title="signin">로그인 하기</a>
+            <div class="header__subtitle">
+                <p>이미 회원이신가요?</p>
+                <a class="text--link" href="/signin.html" title="signin">로그인 하기</a>
+            </div>
+        </header>
+
+        <section class="sign">
+            <form class="form">
+                <div class="form__container">
+                    <label class="form__label" for="signinEmail">이메일</label>
+                    <div class="form__input">
+                        <input class="input__container" id="signinEmail" name="email" type="email">
+                    </div>
                 </div>
-            </header>
 
-            <section class="sign">
-                <form class="form">
-                    <div class="form__container">
-                        <label class="form__label" for="signinEmail">이메일</label>
-                        <div class="form__input">
-                            <input class="input__container" id="signinEmail" name="email" type="email">
-                        </div>
+                <div class="form__container">
+                    <label class="form__label" for="signinPassword">비밀번호</label>
+                    <div class="form__input">
+                        <input class="input__container" id="signinPassword" name="password" type="password">
+                        <button class="input__eyes input__eyes--off" type="button"></button>
                     </div>
-
-                    <div class="form__container">
-                        <label class="form__label" for="signinPassword">비밀번호</label>
-                        <div class="form__input">
-                            <input class="input__container" id="signinPassword" name="password" type="password">
-                            <button class="input__eyes input__eyes--off" type="button"></button>
-                        </div>
-                    </div>
-
-                    <div class="form__container">
-                        <label class="form__label" for="signinPasswordCheck">비밀번호 확인</label>
-                        <div class="form__input">
-                            <input class="input__container" id="signinPasswordCheck" name="password" type="password">
-                            <button class="input__eyes input__eyes--off" type="button"></button>
-                        </div>
-                    </div>
-
-                    <button class="form__btn btn btn--width-full">로그인</button>
-                </form>
-            </section>
-
-            <footer class="footer">
-                <p class="footer__title">다른 방식으로 가입하기</p>
-                <div class="footer__icon">
-                    <a href="https://www.google.com/" target="_blank"><img src="/asset/images/sign_google.png" alt="구글 로그인 아이콘" /></a>
-                    <a href="https://www.kakaocorp.com/page/" target="_blank"><img src="/asset/images/sign_kakao.png" alt="카카오톡 로그인 아이콘" /></a>
                 </div>
-            </footer>
-        </main>
-    </div>
+
+                <div class="form__container">
+                    <label class="form__label" for="signinPasswordCheck">비밀번호 확인</label>
+                    <div class="form__input">
+                        <input class="input__container" id="signinPasswordCheck" name="password" type="password">
+                        <button class="input__eyes input__eyes--off" type="button"></button>
+                    </div>
+                </div>
+
+                <button class="form__btn btn btn--width-full">로그인</button>
+            </form>
+        </section>
+
+        <footer class="footer">
+            <p class="footer__title">다른 방식으로 가입하기</p>
+            <div class="footer__icon">
+                <a href="https://www.google.com/" target="_blank"><img src="/asset/images/sign_google.png" alt="구글 로그인 아이콘" /></a>
+                <a href="https://www.kakaocorp.com/page/" target="_blank"><img src="/asset/images/sign_kakao.png" alt="카카오톡 로그인 아이콘" /></a>
+            </div>
+        </footer>
+    </main>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -12,50 +12,54 @@
 </head>
 
 <body>
-    <header class="header">
-        <h1 class="logo logo--large"><a href="/" title="Linkbrary의 로고"></a></h1>
+    <div class="center_container">
+        <main class="main">
+            <header class="header">
+                <h1 class="logo logo--large"><a href="/" title="Linkbrary의 로고"></a></h1>
 
-        <div class="header__subtitle">
-            <p>이미 회원이신가요?</p>
-            <a class="text--link" href="/signin.html" title="signin">로그인 하기</a>
-        </div>
-    </header>
-
-    <main class="main">
-        <form class="form">
-            <div class="form__container">
-                <label class="form__label" for="signinEmail">이메일</label>
-                <div class="form__input">
-                    <input class="input__container" id="signinEmail" name="email" type="email">
+                <div class="header__subtitle">
+                    <p>이미 회원이신가요?</p>
+                    <a class="text--link" href="/signin.html" title="signin">로그인 하기</a>
                 </div>
-            </div>
+            </header>
 
-            <div class="form__container">
-                <label class="form__label" for="signinPassword">비밀번호</label>
-                <div class="form__input">
-                    <input class="input__container" id="signinPassword" name="password" type="password">
-                    <button class="input__eyes input__eyes--off" type="button"></button>
+            <section class="sign">
+                <form class="form">
+                    <div class="form__container">
+                        <label class="form__label" for="signinEmail">이메일</label>
+                        <div class="form__input">
+                            <input class="input__container" id="signinEmail" name="email" type="email">
+                        </div>
+                    </div>
+
+                    <div class="form__container">
+                        <label class="form__label" for="signinPassword">비밀번호</label>
+                        <div class="form__input">
+                            <input class="input__container" id="signinPassword" name="password" type="password">
+                            <button class="input__eyes input__eyes--off" type="button"></button>
+                        </div>
+                    </div>
+
+                    <div class="form__container">
+                        <label class="form__label" for="signinPasswordCheck">비밀번호 확인</label>
+                        <div class="form__input">
+                            <input class="input__container" id="signinPasswordCheck" name="password" type="password">
+                            <button class="input__eyes input__eyes--off" type="button"></button>
+                        </div>
+                    </div>
+
+                    <button class="form__btn btn btn--width-full">로그인</button>
+                </form>
+            </section>
+
+            <footer class="footer">
+                <p class="footer__title">다른 방식으로 가입하기</p>
+                <div class="footer__icon">
+                    <a href="https://www.google.com/" target="_blank"><img src="/asset/images/sign_google.png" alt="구글 로그인 아이콘" /></a>
+                    <a href="https://www.kakaocorp.com/page/" target="_blank"><img src="/asset/images/sign_kakao.png" alt="카카오톡 로그인 아이콘" /></a>
                 </div>
-            </div>
-
-            <div class="form__container">
-                <label class="form__label" for="signinPasswordCheck">비밀번호 확인</label>
-                <div class="form__input">
-                    <input class="input__container" id="signinPasswordCheck" name="password" type="password">
-                    <button class="input__eyes input__eyes--off" type="button"></button>
-                </div>
-            </div>
-
-            <button class="form__btn btn btn--width-full">로그인</button>
-        </form>
-    </main>
-
-    <footer class="footer">
-        <p class="footer__title">다른 방식으로 가입하기</p>
-        <div class="footer__icon">
-            <a href="https://www.google.com/" target="_blank"><img src="/asset/images/sign_google.png" alt="구글 로그인 아이콘" /></a>
-            <a href="https://www.kakaocorp.com/page/" target="_blank"><img src="/asset/images/sign_kakao.png" alt="카카오톡 로그인 아이콘" /></a>
-        </div>
-    </footer>
+            </footer>
+        </main>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## 요구사항

### 기본
- [x] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용했나요?
- [x] [랜딩 페이지] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정했나요?
- [x] [랜딩 페이지] 미리보기에서 제목은 “Linkbrary”, 설명은 “세상의 모든 정보를 쉽게 저장하고 관리해 보세요”로 설정했나요?
- [x] [랜딩 페이지] 주소와 이미지는 자유롭게 설정했나요?
- [x] [랜딩 페이지] Tablet 사이즈에서 화면의 너비가 1199px 이하로 작아질 때 “Linkbrary” 로고와 “로그인” 버튼 사이의 간격은 유지하고 좌우 여백이 줄어드나요?
- [x] [랜딩 페이지] 최소 좌우 여백은 “Linkbrary” 로고의 왼쪽에 여백 32px, “로그인” 버튼 오른쪽 여백 32px을 유지할 수 있도록 “Linkbrary” 로고와 “로그인" 버튼의 간격이 가까워지나요?
- [x] [랜딩 페이지] PC, Tablet 사이즈의 이미지 크기는 고정값을 사용했나요?
- [x] [랜딩 페이지] Mobile 사이즈의 이미지는 좌우 여백 32px을 제외하고 이미지 영역이 꽉 차나요? (이때 가로가 커지는 비율에 맞춰 세로도 커져야 합니다.)
- [x] [랜딩 페이지] Mobile 사이즈 너비가 커지면, “Privacy Policy”, “FAQ”, “codeit-2023”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 커지나요?
- [x] [로그인, 회원가입 페이지] Tablet 사이즈에서 디자인은 PC사이즈와 동일한가요?
- [x] [로그인, 회원가입 페이지] Mobile 사이즈에서 좌우 여백 32px 제외하고 내부 요소들이 너비를 모두 차지하나요?
- [x] [로그인, 회원가입 페이지] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않나요?


### 심화
- [x] 랜딩 페이지 Mobile 사이즈에서 제품 소개 영역의 순서를 제목, 설명, 이미지 => 제목, 이미지, 설명 순서로 변경했나요?
- [ ] 팀원의 위클리 미션 PR에 코드 리뷰를 남겼나요?

## 주요 변경사항

- 전 페이지에 걸쳐서 화면의 넓이에 따라 반응하도록 미디어쿼리 사용
- index.html에 오픈그래프를 이용한 메타데이터 삽입


## 멘토에게

- 같은 컴포넌트(.btn)가 index.html에서는 화면 넓이에 따라 글자 크기와 패딩값이 줄어들고, sign에서는 변하지 않습니다. 그렇다면 좁은 화면에서만 반응하는 컴포넌트 클래스(가령 .btn--media768 과 같은 형태로)를 compo.css에 미디어쿼리로 마련하는 게 좋을까요? 아니면 그냥 지금처럼 index.html에서만 .btn이 변하도록 index.css에 미디어쿼리를 배치하는 게 좋을까요? (커밋 [1ffd657](https://github.com/codeit-bootcamp-frontend/1-Weekly-Mission/pull/71/commits/1ffd6579b0312a12afc57d4d3e7556ae35fede55) 문제)