### PR TITLE
[박소현] week4

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,26 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "es2021": true
+    },
+    "extends": "eslint:recommended",
+    "overrides": [
+        {
+            "env": {
+                "node": true
+            },
+            "files": [
+                ".eslintrc.{js,cjs}"
+            ],
+            "parserOptions": {
+                "sourceType": "script"
+            }
+        }
+    ],
+    "parserOptions": {
+        "ecmaVersion": "latest",
+        "sourceType": "module"
+    },
+    "rules": {
+    }
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 120,
+  "tabWidth": 2,
+  "trailingComma": "all"
+}

--- a/Linkbrary/css/sign_form.css
+++ b/Linkbrary/css/sign_form.css
@@ -66,6 +66,10 @@
   }
 }
 
+.error {
+  border-color: var(--color-red);
+}
+
 .form__input--selected {
   position: relative;
   top: 5px;

--- a/Linkbrary/css/sign_form.css
+++ b/Linkbrary/css/sign_form.css
@@ -86,6 +86,12 @@
   cursor: pointer;
 }
 
+.form__errorMessage {
+  margin: 0;
+  color: var(--color-red);
+  font-size: 0.875rem;
+}
+
 .form-container__oauth {
   width: 400px;
   padding: 1rem 2rem;

--- a/Linkbrary/folder.html
+++ b/Linkbrary/folder.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Folder Page</title>
+  </head>
+  <body>
+    <div>folder page</div>
+  </body>
+</html>

--- a/Linkbrary/signin.html
+++ b/Linkbrary/signin.html
@@ -29,7 +29,7 @@
             <div class="form-container__link__underline"></div>
           </div>
         </div>
-        <form class="form">
+        <form class="form" action="folder.html">
           <label class="form__title">이메일</label>
           <input
             id="email"

--- a/Linkbrary/signin.html
+++ b/Linkbrary/signin.html
@@ -6,6 +6,7 @@
     <title>Signin Page</title>
     <link rel="stylesheet" href="css/reset.css" />
     <link rel="stylesheet" href="css/sign_form.css" />
+    <script type="module" src="src/signin.js" defer></script>
   </head>
   <body>
     <div class="container">
@@ -31,13 +32,16 @@
         <form class="form">
           <label class="form__title">이메일</label>
           <input
+            id="email"
             class="form__input"
             placeholder="이메일을 입력해주세요."
             type="text"
           />
+          <p id="emailError" class="form__errorMessage"></p>
           <label class="form__title">비밀번호</label>
           <div>
             <input
+              id="password"
               class="form__input"
               placeholder="비밀번호를 입력해주세요."
               type="password"
@@ -48,6 +52,7 @@
               alt="비밀번호 숨기기 기능"
             />
           </div>
+          <p id="passwordError" class="form__errorMessage"></p>
           <a>
             <button class="form__button">로그인</button>
           </a>

--- a/Linkbrary/signin.html
+++ b/Linkbrary/signin.html
@@ -37,6 +37,7 @@
             class="form__input"
             placeholder="이메일을 입력해주세요."
             type="text"
+            autocomplete="off"
           />
           <p id="emailError" class="form__errorMessage"></p>
           <label class="form__title">비밀번호</label>
@@ -46,6 +47,7 @@
               class="form__input"
               placeholder="비밀번호를 입력해주세요."
               type="password"
+              autocomplete="off"
             />
             <img
               class="form__input--selected"

--- a/Linkbrary/signin.html
+++ b/Linkbrary/signin.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="css/reset.css" />
     <link rel="stylesheet" href="css/sign_form.css" />
     <script type="module" src="src/signin.js" defer></script>
+    <script type="module" src="src/common/hiddenPassword.js" defer></script>
   </head>
   <body>
     <div class="container">

--- a/Linkbrary/src/common/hiddenPassword.js
+++ b/Linkbrary/src/common/hiddenPassword.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const eyeIcons = document.querySelectorAll(".form__input--selected");
+
+// 비밀번호 가리기 토글 기능 - selected 상태에 따라 type과 src를 변경
+const hiddenPasswordToggle = (e) => {
+  const input = e.target.previousElementSibling;
+  input.classList.toggle("selected");
+
+  const isSelected = input.classList.contains("selected");
+  if (isSelected) {
+    input.setAttribute("type", "text");
+    e.target.setAttribute("src", "images/eye-on.svg");
+  } else {
+    input.setAttribute("type", "password");
+    e.target.setAttribute("src", "images/eye-off.svg");
+  }
+};
+
+eyeIcons.forEach((icon) =>
+  icon.addEventListener("click", hiddenPasswordToggle)
+);

--- a/Linkbrary/src/common/hiddenPassword.js
+++ b/Linkbrary/src/common/hiddenPassword.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const eyeIcons = document.querySelectorAll(".form__input--selected");
 
 // 비밀번호 가리기 토글 기능 - selected 상태에 따라 type과 src를 변경
@@ -8,13 +6,10 @@ const hiddenPasswordToggle = (e) => {
   input.classList.toggle("selected");
 
   const isSelected = input.classList.contains("selected");
-  if (isSelected) {
-    input.setAttribute("type", "text");
-    e.target.setAttribute("src", "images/eye-on.svg");
-  } else {
-    input.setAttribute("type", "password");
-    e.target.setAttribute("src", "images/eye-off.svg");
-  }
+  const pwIconPath = isSelected ? "images/eye-on.svg" : "images/eye-off.svg";
+
+  input.setAttribute("type", isSelected ? "text" : "password");
+  e.target.setAttribute("src", pwIconPath);
 };
 
 eyeIcons.forEach((icon) =>

--- a/Linkbrary/src/signin.js
+++ b/Linkbrary/src/signin.js
@@ -1,4 +1,5 @@
 const input = document.querySelector(".form__input");
+const form = document.querySelector(".form");
 
 const email = document.getElementById("email");
 const password = document.getElementById("password");
@@ -36,9 +37,27 @@ const checkPasswordValue = () => {
   }
 };
 
+// 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동
+const onClickSubmit = (e) => {
+  e.preventDefault();
+
+  if (!email.value || !password.value) {
+    checkEmailValue();
+    checkPasswordValue();
+    return;
+  }
+  if (email.value === "test@codeit.com" && password.value === "codeit101") {
+    form.submit();
+  } else {
+    // 이외의 로그인 시도의 경우, 이메일 input, 비밀번호 input 아래에 해당 에러 메세지
+    emailError.textContent = "이메일을 확인해주세요";
+    email.style.borderColor = "var(--color-red)";
+    passwordError.textContent = "비밀번호를 확인해주세요";
+    password.style.borderColor = "var(--color-red)";
+  }
+  // console.log(e);
+};
+
 email.addEventListener("focusout", checkEmailValue);
 password.addEventListener("focusout", checkPasswordValue);
-
-// To-do
-// 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동
-// 이외의 로그인 시도의 경우, 이메일 input, 비밀번호 input 아래에 해당 에러 메세지
+form.addEventListener("submit", onClickSubmit);

--- a/Linkbrary/src/signin.js
+++ b/Linkbrary/src/signin.js
@@ -11,27 +11,6 @@ const password = document.getElementById("password");
 const emailError = document.getElementById("emailError");
 const passwordError = document.getElementById("passwordError");
 
-const eyeIcon = document.querySelector(".form__input--selected");
-let isSelected = true;
-
-// 1-1. 비밀번호 가리기 기능 - selected 상태를 변경하는 로직
-const onClickHiddenPassword = () => {
-  isSelected = !isSelected;
-
-  // 1-2. 비밀번호 가리기 기능 - selected 상태에 따라 type과 src를 변경하는 로직
-  changePasswordType();
-};
-
-function changePasswordType() {
-  if (isSelected) {
-    password.setAttribute("type", "password");
-    eyeIcon.setAttribute("src", "images/eye-off.svg");
-  } else {
-    password.setAttribute("type", "text");
-    eyeIcon.setAttribute("src", "images/eye-on.svg");
-  }
-}
-
 // 이메일 input에서 focus out할 때, 이메일 형식에 맞지 않는 값이 있는 경우 에러메세지
 const regExp = /^[a-zA-Z0-9]+@[a-zA-Z]+\.[a-zA-Z]{2,3}$/i;
 
@@ -87,5 +66,4 @@ const onClickSubmit = (e) => {
 
 email.addEventListener("focusout", checkEmailValue);
 password.addEventListener("focusout", checkPasswordValue);
-eyeIcon.addEventListener("click", onClickHiddenPassword);
 form.addEventListener("submit", onClickSubmit);

--- a/Linkbrary/src/signin.js
+++ b/Linkbrary/src/signin.js
@@ -6,11 +6,26 @@ const password = document.getElementById("password");
 const emailError = document.getElementById("emailError");
 const passwordError = document.getElementById("passwordError");
 
+// 이메일 input에서 focus out할 때, 이메일 형식에 맞지 않는 값이 있는 경우 에러메세지
+const regExp = /^[a-zA-Z0-9]+@[a-zA-Z]+\.[a-zA-Z]{2,3}$/i;
+
+const emailValidation = (value) => {
+  if (!regExp.test(value)) {
+    emailError.textContent = "올바른 이메일 주소가 아닙니다.";
+    email.style.borderColor = "var(--color-red)";
+  } else {
+    emailError.textContent = "";
+    email.style.borderColor = "var(--color-gray-20)";
+  }
+};
+
 // 이메일, 비밀번호 input에서 focus out할 때, 값이 없을 경우 에러메세지
 const checkEmailValue = () => {
   if (!email.value) {
     emailError.textContent = "이메일을 입력해주세요";
     email.style.borderColor = "var(--color-red)";
+  } else {
+    emailValidation(email.value);
   }
 };
 
@@ -25,6 +40,5 @@ email.addEventListener("focusout", checkEmailValue);
 password.addEventListener("focusout", checkPasswordValue);
 
 // To-do
-// 이메일 input에서 focus out할 때, 이메일 형식에 맞지 않는 값이 있는 경우 에러메세지
 // 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동
 // 이외의 로그인 시도의 경우, 이메일 input, 비밀번호 input 아래에 해당 에러 메세지

--- a/Linkbrary/src/signin.js
+++ b/Linkbrary/src/signin.js
@@ -1,0 +1,30 @@
+const input = document.querySelector(".form__input");
+
+const email = document.getElementById("email");
+const password = document.getElementById("password");
+
+const emailError = document.getElementById("emailError");
+const passwordError = document.getElementById("passwordError");
+
+// 이메일, 비밀번호 input에서 focus out할 때, 값이 없을 경우 에러메세지
+const checkEmailValue = () => {
+  if (!email.value) {
+    emailError.textContent = "이메일을 입력해주세요";
+    email.style.borderColor = "var(--color-red)";
+  }
+};
+
+const checkPasswordValue = () => {
+  if (!password.value) {
+    passwordError.textContent = "비밀번호를 입력해주세요";
+    password.style.borderColor = "var(--color-red)";
+  }
+};
+
+email.addEventListener("focusout", checkEmailValue);
+password.addEventListener("focusout", checkPasswordValue);
+
+// To-do
+// 이메일 input에서 focus out할 때, 이메일 형식에 맞지 않는 값이 있는 경우 에러메세지
+// 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동
+// 이외의 로그인 시도의 경우, 이메일 input, 비밀번호 input 아래에 해당 에러 메세지

--- a/Linkbrary/src/signin.js
+++ b/Linkbrary/src/signin.js
@@ -1,4 +1,8 @@
-const input = document.querySelector(".form__input");
+"use strict";
+
+const USER_EMAIL = "test@codeit.com";
+const USER_PASSWORD = "codeit101";
+
 const form = document.querySelector(".form");
 
 const email = document.getElementById("email");
@@ -34,10 +38,10 @@ const regExp = /^[a-zA-Z0-9]+@[a-zA-Z]+\.[a-zA-Z]{2,3}$/i;
 const emailValidation = (value) => {
   if (!regExp.test(value)) {
     emailError.textContent = "올바른 이메일 주소가 아닙니다.";
-    email.style.borderColor = "var(--color-red)";
+    email.classList.add("error");
   } else {
     emailError.textContent = "";
-    email.style.borderColor = "var(--color-gray-20)";
+    email.classList.remove("error");
   }
 };
 
@@ -45,7 +49,7 @@ const emailValidation = (value) => {
 const checkEmailValue = () => {
   if (!email.value) {
     emailError.textContent = "이메일을 입력해주세요";
-    email.style.borderColor = "var(--color-red)";
+    email.classList.add("error");
   } else {
     emailValidation(email.value);
   }
@@ -54,7 +58,10 @@ const checkEmailValue = () => {
 const checkPasswordValue = () => {
   if (!password.value) {
     passwordError.textContent = "비밀번호를 입력해주세요";
-    password.style.borderColor = "var(--color-red)";
+    password.classList.add("error");
+  } else {
+    passwordError.textContent = "";
+    password.classList.remove("error");
   }
 };
 
@@ -67,16 +74,15 @@ const onClickSubmit = (e) => {
     checkPasswordValue();
     return;
   }
-  if (email.value === "test@codeit.com" && password.value === "codeit101") {
+  if (email.value === USER_EMAIL && password.value === USER_PASSWORD) {
     form.submit();
   } else {
     // 이외의 로그인 시도의 경우, 이메일 input, 비밀번호 input 아래에 해당 에러 메세지
     emailError.textContent = "이메일을 확인해주세요";
-    email.style.borderColor = "var(--color-red)";
+    email.classList.add("error");
     passwordError.textContent = "비밀번호를 확인해주세요";
-    password.style.borderColor = "var(--color-red)";
+    password.classList.add("error");
   }
-  // console.log(e);
 };
 
 email.addEventListener("focusout", checkEmailValue);

--- a/Linkbrary/src/signin.js
+++ b/Linkbrary/src/signin.js
@@ -12,7 +12,7 @@ const passwordError = document.getElementById("passwordError");
 const addErrorClass = (el) => el.classList.add("error");
 const removeErrorClass = (el) => el.classList.remove("error");
 
-// 이메일 input에서 focus out할 때, 이메일 형식에 맞지 않는 값이 있는 경우 에러메세지
+/** 이메일 형식 검증 */
 const emailRegExp = /^[a-zA-Z0-9]+@[a-zA-Z]+\.[a-zA-Z]{2,3}$/i;
 
 const emailValidation = (value) => {
@@ -23,37 +23,43 @@ const emailValidation = (value) => {
   isEmailValid ? removeErrorClass(email) : addErrorClass(email);
 };
 
-// 이메일, 비밀번호 input에서 focus out할 때, 값이 없을 경우 에러메세지
-const checkEmailValue = () => {
+/** 비밀번호 있으면 에러메세지 초기화 */
+const passwordInputReset = () => {
+  passwordError.textContent = "";
+  removeErrorClass(password);
+};
+
+/** 이메일, 비밀번호 focus out할 때, value 체크 */
+const checkFormValue = (e) => {
+  if (!e.target.classList.contains("form__input")) return;
+
+  const { value, id } = e.target;
+  const context = id === "email" ? "이메일을" : "비밀번호를";
+
+  if (!value) {
+    document.getElementById(`${id}Error`).textContent = `${context} 입력해주세요`;
+    addErrorClass(e.target);
+    return;
+  }
+  id === "email" ? emailValidation(e.target.value) : passwordInputReset();
+};
+
+/** 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동  */
+const onClickSubmit = (e) => {
+  e.preventDefault();
+
   if (!email.value) {
     emailError.textContent = "이메일을 입력해주세요";
     addErrorClass(email);
     return;
   }
-  emailValidation(email.value);
-};
-
-const checkPasswordValue = () => {
   if (!password.value) {
     passwordError.textContent = "비밀번호를 입력해주세요";
     addErrorClass(password);
     return;
   }
-  passwordError.textContent = "";
-  removeErrorClass(password);
-};
 
-// 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동
-const onClickSubmit = (e) => {
-  e.preventDefault();
-
-  if (!email.value || !password.value) {
-    checkEmailValue();
-    checkPasswordValue();
-    return;
-  }
-
-  // 이외의 로그인 시도의 경우, 이메일 input, 비밀번호 input 아래에 해당 에러 메세지
+  /** 이외의 로그인 시도의 경우, 이메일 input, 비밀번호 input 아래에 해당 에러 메세지 */
   if (email.value !== USER_EMAIL || password.value !== USER_PASSWORD) {
     emailError.textContent = "이메일을 확인해주세요";
     passwordError.textContent = "비밀번호를 확인해주세요";
@@ -64,6 +70,5 @@ const onClickSubmit = (e) => {
   form.submit();
 };
 
-email.addEventListener("focusout", checkEmailValue);
-password.addEventListener("focusout", checkPasswordValue);
+form.addEventListener("focusout", checkFormValue);
 form.addEventListener("submit", onClickSubmit);

--- a/Linkbrary/src/signin.js
+++ b/Linkbrary/src/signin.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const USER_EMAIL = "test@codeit.com";
 const USER_PASSWORD = "codeit101";
 
@@ -11,37 +9,38 @@ const password = document.getElementById("password");
 const emailError = document.getElementById("emailError");
 const passwordError = document.getElementById("passwordError");
 
+const addErrorClass = (el) => el.classList.add("error");
+const removeErrorClass = (el) => el.classList.remove("error");
+
 // 이메일 input에서 focus out할 때, 이메일 형식에 맞지 않는 값이 있는 경우 에러메세지
-const regExp = /^[a-zA-Z0-9]+@[a-zA-Z]+\.[a-zA-Z]{2,3}$/i;
+const emailRegExp = /^[a-zA-Z0-9]+@[a-zA-Z]+\.[a-zA-Z]{2,3}$/i;
 
 const emailValidation = (value) => {
-  if (!regExp.test(value)) {
-    emailError.textContent = "올바른 이메일 주소가 아닙니다.";
-    email.classList.add("error");
-  } else {
-    emailError.textContent = "";
-    email.classList.remove("error");
-  }
+  const isEmailValid = emailRegExp.test(value);
+  const context = isEmailValid ? "" : "올바른 이메일 주소가 아닙니다.";
+
+  emailError.textContent = context;
+  isEmailValid ? removeErrorClass(email) : addErrorClass(email);
 };
 
 // 이메일, 비밀번호 input에서 focus out할 때, 값이 없을 경우 에러메세지
 const checkEmailValue = () => {
   if (!email.value) {
     emailError.textContent = "이메일을 입력해주세요";
-    email.classList.add("error");
-  } else {
-    emailValidation(email.value);
+    addErrorClass(email);
+    return;
   }
+  emailValidation(email.value);
 };
 
 const checkPasswordValue = () => {
   if (!password.value) {
     passwordError.textContent = "비밀번호를 입력해주세요";
-    password.classList.add("error");
-  } else {
-    passwordError.textContent = "";
-    password.classList.remove("error");
+    addErrorClass(password);
+    return;
   }
+  passwordError.textContent = "";
+  removeErrorClass(password);
 };
 
 // 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동
@@ -53,15 +52,16 @@ const onClickSubmit = (e) => {
     checkPasswordValue();
     return;
   }
-  if (email.value === USER_EMAIL && password.value === USER_PASSWORD) {
-    form.submit();
-  } else {
-    // 이외의 로그인 시도의 경우, 이메일 input, 비밀번호 input 아래에 해당 에러 메세지
+
+  // 이외의 로그인 시도의 경우, 이메일 input, 비밀번호 input 아래에 해당 에러 메세지
+  if (email.value !== USER_EMAIL || password.value !== USER_PASSWORD) {
     emailError.textContent = "이메일을 확인해주세요";
-    email.classList.add("error");
     passwordError.textContent = "비밀번호를 확인해주세요";
-    password.classList.add("error");
+    addErrorClass(email);
+    addErrorClass(password);
+    return;
   }
+  form.submit();
 };
 
 email.addEventListener("focusout", checkEmailValue);

--- a/Linkbrary/src/signin.js
+++ b/Linkbrary/src/signin.js
@@ -7,6 +7,27 @@ const password = document.getElementById("password");
 const emailError = document.getElementById("emailError");
 const passwordError = document.getElementById("passwordError");
 
+const eyeIcon = document.querySelector(".form__input--selected");
+let isSelected = true;
+
+// 1-1. 비밀번호 가리기 기능 - selected 상태를 변경하는 로직
+const onClickHiddenPassword = () => {
+  isSelected = !isSelected;
+
+  // 1-2. 비밀번호 가리기 기능 - selected 상태에 따라 type과 src를 변경하는 로직
+  changePasswordType();
+};
+
+function changePasswordType() {
+  if (isSelected) {
+    password.setAttribute("type", "password");
+    eyeIcon.setAttribute("src", "images/eye-off.svg");
+  } else {
+    password.setAttribute("type", "text");
+    eyeIcon.setAttribute("src", "images/eye-on.svg");
+  }
+}
+
 // 이메일 input에서 focus out할 때, 이메일 형식에 맞지 않는 값이 있는 경우 에러메세지
 const regExp = /^[a-zA-Z0-9]+@[a-zA-Z]+\.[a-zA-Z]{2,3}$/i;
 
@@ -60,4 +81,5 @@ const onClickSubmit = (e) => {
 
 email.addEventListener("focusout", checkEmailValue);
 password.addEventListener("focusout", checkPasswordValue);
+eyeIcon.addEventListener("click", onClickHiddenPassword);
 form.addEventListener("submit", onClickSubmit);


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동하나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보이나요?
- [x] 이외의 로그인 시도의 경우 이메일, 비밀번호 input에 빨강색 테두리와 각각의 input아래에 “이메일을 확인해주세요.”, “비밀번호를 확인해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일, 비밀번호 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?  

### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?

## 주요 변경사항

- 로그인 페이지의 이메일, 비밀번호 input 유효성 검증
- 로그인 버튼 클릭시 페이지 이동
- 비밀번호 가리기 기능 구현(공통 파일로 분리)

## 스크린샷
![스크린샷 2023-09-29 오후 7 06 11](https://github.com/codeit-bootcamp-frontend/1-Weekly-Mission/assets/124856726/243c7e7c-da4c-485c-82b9-4e50c2f32828)

![스크린샷 2023-09-29 오후 7 08 47](https://github.com/codeit-bootcamp-frontend/1-Weekly-Mission/assets/124856726/2bb27cbc-013b-4930-ae8b-b719c2be0ccc)

![스크린샷 2023-09-29 오후 7 09 25](https://github.com/codeit-bootcamp-frontend/1-Weekly-Mission/assets/124856726/db050603-5fe2-44a6-8ad9-8f06bae18ea4)

## 멘토에게

- 기능 구현 관련하여 피드백 부탁드립니다. 감사합니다.
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
