### PR TITLE
[손지은] week4

### DIFF
--- a/css/1-Weekly-Mission.code-workspace
+++ b/css/1-Weekly-Mission.code-workspace
@@ -5,6 +5,7 @@
 		}
 	],
 	"settings": {
-		"liveServer.settings.multiRootWorkspaceName": "1-Weekly-Mission"
+		"liveServer.settings.multiRootWorkspaceName": "1-Weekly-Mission",
+		"liveServer.settings.port": 5501
 	}
 }

--- a/css/index.css
+++ b/css/index.css
@@ -268,6 +268,16 @@ footer{
     justify-content: space-around;
     align-items: center;
 }
+@media(max-width : 76.7rem){
+
+    footer{
+        display: grid;
+        grid-template-areas: 
+            "extra_sites footer_icons"
+            "since_codeit .";
+        gap: 3rem;
+    }
+}
 
 footer .since_codeit{
     color: #676767;
@@ -307,14 +317,6 @@ button:hover{
 }
 
 @media(max-width : 76.7rem){
-
-    footer{
-        display: grid;
-        grid-template-areas: 
-            "extra_sites footer_icons"
-            "since_codeit .";
-        gap: 3rem;
-    }
     .not-mobile-br{
         display: none;
     }

--- a/css/sign.css
+++ b/css/sign.css
@@ -64,7 +64,7 @@ header p{
 .form__sign label{
     font-size: 1.4rem;
 }
-.form__sign input{
+.email_input,.pwd_input,.check_pwd_input{
     padding: 1.8rem 1.5rem;
     border: 0.1rem solid var(--linkbrary-gray-20);
     border-radius: 0.8rem;
@@ -122,4 +122,11 @@ header p{
     bottom:50%;
     transform: translateY(50%);
     fill: white;
+}
+.email_error_message{
+    display: none;
+    color: red;
+}
+.border-red{
+    border-color: red;
 }

--- a/css/sign.css
+++ b/css/sign.css
@@ -115,7 +115,7 @@ header p{
     flex-direction: column;
 }
 .form__input-wrapper input{
-    padding-right: 1.6rem;
+    padding-right: 4rem;
 } 
 
 .password-eye{

--- a/css/sign.css
+++ b/css/sign.css
@@ -80,6 +80,7 @@ header p{
     color: var(--grey-light);
     border-radius: 0.8rem;
     font-size: 1.8rem;
+    cursor: pointer;
 }
 
 .social-sign{
@@ -123,6 +124,7 @@ header p{
     bottom:50%;
     transform: translateY(50%);
     fill: white;
+    cursor: pointer;
 }
 .email_error_message,.pwd_error_message{
     display: none;

--- a/css/sign.css
+++ b/css/sign.css
@@ -71,6 +71,7 @@ header p{
 }
 .form__sign input:focus-visible{
     outline-color: var(--linkbrary-primary-color);
+
 }
 .btn-sign{
     padding: 1.6rem 2rem;
@@ -123,7 +124,7 @@ header p{
     transform: translateY(50%);
     fill: white;
 }
-.email_error_message{
+.email_error_message,.pwd_error_message{
     display: none;
     color: red;
 }

--- a/html/signin.html
+++ b/html/signin.html
@@ -15,7 +15,7 @@
             <p>회원이 아니신가요?<a href="/html/signup.html" class="header__sign-link">회원 가입하기</a></p>
         </header>
         <div class="container">
-            <form action="post" class="form__sign">
+            <form action="/folder" method="post" class="form__sign" >
                 <div class="form__wrapper">
                     <label for="email_input">이메일</label>
                     <input type="email" class="email_input" id="email_input" name="email">

--- a/html/signin.html
+++ b/html/signin.html
@@ -24,9 +24,10 @@
                 <div class="form__wrapper">
                     <label for="pwd_input">비밀번호</label>
                     <div class="form__input-wrapper">
-                    <input type="password" class="pwd_input" id="pwd_input" name="password">
-                    <img src="/img/eye-off.svg" alt="" class="password-eye">
-                </div>
+                        <input type="password" class="pwd_input" id="pwd_input" name="password">
+                        <img src="/img/eye-off.svg" alt="" class="password-eye">
+                    </div>
+                    <div class="pwd_error_message"></div>
                 </div>
                 
                 <button class="btn-sign">로그인</button>

--- a/html/signin.html
+++ b/html/signin.html
@@ -19,6 +19,7 @@
                 <div class="form__wrapper">
                     <label for="email_input">이메일</label>
                     <input type="email" class="email_input" id="email_input" name="email">
+                    <div class="email_error_message"></div>
                 </div>
                 <div class="form__wrapper">
                     <label for="pwd_input">비밀번호</label>
@@ -39,5 +40,6 @@
             </div>
         </div>
     </div>
+    <script src="/script/sign.js"></script>
 </body>
 </html>

--- a/script/sign.js
+++ b/script/sign.js
@@ -1,5 +1,10 @@
 const $emailErrorMessage = document.querySelector('.email_error_message');
+const $pwdErrorMessage = document.querySelector('.pwd_error_message');
 const $email = document.querySelector('.email_input');
+const $pwd = document.querySelector('.pwd_input');
+
+let emailValid = false;
+let pwdValid = false;
 
 function emailErrorMessage(e){
     if(e.target.value === ""){
@@ -15,7 +20,22 @@ function emailErrorMessage(e){
    else{
     $emailErrorMessage.style.display ="none";
     $email.classList.remove("border-red");
+    emailValid = true;
    }
 }
 
+function pwdErrorMessage(e){
+    console.log(e)
+    if(e.target.value === ""){
+        $pwdErrorMessage.textContent = "비밀번호를 입력해주세요."
+        $pwdErrorMessage.style.display ="block";
+        $pwd.classList.add('border-red');
+    }
+    else{
+        $pwdErrorMessage.style.display ="none";
+        $pwd.classList.remove("border-red");
+        pwdValid = true;
+    }
+}
 $email.addEventListener("focusout",emailErrorMessage);
+$pwd.addEventListener("focusout",pwdErrorMessage);

--- a/script/sign.js
+++ b/script/sign.js
@@ -2,6 +2,7 @@ const $emailErrorMessage = document.querySelector('.email_error_message');
 const $pwdErrorMessage = document.querySelector('.pwd_error_message');
 const $email = document.querySelector('.email_input');
 const $pwd = document.querySelector('.pwd_input');
+const $signBtn = document.querySelector('.btn-sign');
 
 let emailValid = false;
 let pwdValid = false;
@@ -39,3 +40,17 @@ function pwdErrorMessage(e){
 }
 $email.addEventListener("focusout",emailErrorMessage);
 $pwd.addEventListener("focusout",pwdErrorMessage);
+
+function signinValidCheck(e){
+    if(!emailValid){
+        $emailErrorMessage.textContent = "이메일을 확인해주세요."
+        $emailErrorMessage.style.display ="block";
+        e.preventDefault();
+    }
+    if(!pwdValid){
+        $pwdErrorMessage.textContent = "비밀번호를 확인해주세요."
+        $pwdErrorMessage.style.display ="block";
+        e.preventDefault();
+    }
+}
+$signBtn.addEventListener('click',signinValidCheck);

--- a/script/sign.js
+++ b/script/sign.js
@@ -1,0 +1,21 @@
+const $emailErrorMessage = document.querySelector('.email_error_message');
+const $email = document.querySelector('.email_input');
+
+function emailErrorMessage(e){
+    if(e.target.value === ""){
+        $emailErrorMessage.textContent = "이메일을 입력해주세요."
+        $emailErrorMessage.style.display ="block";
+        $email.classList.add('border-red');
+    }
+   else if(!e.target.value.includes('@')){
+        $emailErrorMessage.textContent = "올바른 이메일 주소가 아닙니다."
+        $emailErrorMessage.style.display ="block";
+        $email.classList.add('border-red');
+   }
+   else{
+    $emailErrorMessage.style.display ="none";
+    $email.classList.remove("border-red");
+   }
+}
+
+$email.addEventListener("focusout",emailErrorMessage);

--- a/script/sign.js
+++ b/script/sign.js
@@ -9,6 +9,7 @@ let emailValid = false;
 let pwdValid = false;
 
 function emailErrorMessage(e){
+    emailValid = false;
     if(e.target.value === ""){
         $emailErrorMessage.textContent = "이메일을 입력해주세요."
         $emailErrorMessage.style.display ="block";
@@ -27,6 +28,7 @@ function emailErrorMessage(e){
 }
 
 function pwdErrorMessage(e){
+    pwdValid=false;
     if(e.target.value === ""){
         $pwdErrorMessage.textContent = "비밀번호를 입력해주세요."
         $pwdErrorMessage.style.display ="block";

--- a/script/sign.js
+++ b/script/sign.js
@@ -3,6 +3,7 @@ const $pwdErrorMessage = document.querySelector('.pwd_error_message');
 const $email = document.querySelector('.email_input');
 const $pwd = document.querySelector('.pwd_input');
 const $signBtn = document.querySelector('.btn-sign');
+const $pwdEye = document.querySelector('.password-eye');
 
 let emailValid = false;
 let pwdValid = false;
@@ -26,7 +27,6 @@ function emailErrorMessage(e){
 }
 
 function pwdErrorMessage(e){
-    console.log(e)
     if(e.target.value === ""){
         $pwdErrorMessage.textContent = "비밀번호를 입력해주세요."
         $pwdErrorMessage.style.display ="block";
@@ -54,3 +54,17 @@ function signinValidCheck(e){
     }
 }
 $signBtn.addEventListener('click',signinValidCheck);
+
+let eyeOn = false;
+function pwdEyeOnOff(e){
+    eyeOn = !eyeOn;
+    if(eyeOn){
+        e.target.src = "/img/eye-on.svg";
+        $pwd.type ="text";
+    }
+    else{
+        e.target.src = "/img/eye-off.svg";
+        $pwd.type ="password";
+    }
+}
+$pwdEye.addEventListener('click',pwdEyeOnOff);


### PR DESCRIPTION
## 요구사항

### 기본
배포주소 - https://jieun-linkbrary.netlify.app/
- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동하나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보이나요?
- [x] 이외의 로그인 시도의 경우 이메일, 비밀번호 input에 빨강색 테두리와 각각의 input아래에 “이메일을 확인해주세요.”, “비밀번호를 확인해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일, 비밀번호 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?


### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?



## 스크린샷
<img width="599" alt="스크린샷 2023-10-01 오후 2 35 09" src="https://github.com/codeit-bootcamp-frontend/1-Weekly-Mission/assets/144668146/88dc99eb-df41-4393-91a9-ba8e7de55417">

## 멘토에게

- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
