### PR TITLE
[안성재] Week5

### DIFF
--- a/html/signin.html
+++ b/html/signin.html
@@ -33,8 +33,8 @@
             <span class="alert-message"></span>
             <span class="eye-button">
               <button type="button">
-                <img class="eye-icon" src="/images/eye-off.svg" alt="비밀번호 표시 off 아이콘" />
-                <img class="eye-icon off" src="/images/eye-on.svg" alt="비밀번호 표시 on 아이콘" />
+                <img class="eye-icon eye-off" src="/images/eye-off.svg" alt="비밀번호 표시 off 아이콘" />
+                <img class="eye-icon eye-on display-none" src="/images/eye-on.svg" alt="비밀번호 표시 on 아이콘" />
               </button>
             </span>
           </div>

--- a/html/signin.html
+++ b/html/signin.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
     <link rel="stylesheet" href="/src/globalStyles.css" />
     <link rel="stylesheet" href="/src/sign.css" />
-    <script defer src="/js/signin.js"></script>
+    <script defer type="module" src="/js/signin.js"></script>
   </head>
   <body>
     <header>

--- a/html/signup.html
+++ b/html/signup.html
@@ -40,7 +40,7 @@
           </div>
           <div class="input-area password-input-area">
             <label for="password">비밀번호 확인</label>
-            <input class="password" name="password" placeholder="비밀번호 입력" type="password" />
+            <input class="password-confirm" name="password" placeholder="비밀번호 입력" type="password" />
             <span class="alert-message"></span>
             <span class="eye-button">
               <button type="button">

--- a/html/signup.html
+++ b/html/signup.html
@@ -33,8 +33,8 @@
             <span class="alert-message"></span>
             <span class="eye-button">
               <button type="button">
-                <img class="eye-icon" src="/images/eye-off.svg" alt="비밀번호 표시 off 아이콘" />
-                <img class="eye-icon off" src="/images/eye-on.svg" alt="비밀번호 표시 on 아이콘" />
+                <img class="eye-icon eye-off" src="/images/eye-off.svg" alt="비밀번호 표시 off 아이콘" />
+                <img class="eye-icon eye-on display-none" src="/images/eye-on.svg" alt="비밀번호 표시 on 아이콘" />
               </button>
             </span>
           </div>
@@ -44,8 +44,8 @@
             <span class="alert-message"></span>
             <span class="eye-button">
               <button type="button">
-                <img class="eye-icon" src="/images/eye-off.svg" alt="비밀번호 표시 off 아이콘" />
-                <img class="eye-icon off" src="/images/eye-on.svg" alt="비밀번호 표시 on 아이콘" />
+                <img class="eye-icon eye-off" src="/images/eye-off.svg" alt="비밀번호 표시 off 아이콘" />
+                <img class="eye-icon eye-on display-none" src="/images/eye-on.svg" alt="비밀번호 표시 on 아이콘" />
               </button>
             </span>
           </div>

--- a/html/signup.html
+++ b/html/signup.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
     <link rel="stylesheet" href="/src/globalStyles.css" />
     <link rel="stylesheet" href="/src/sign.css" />
-    <script defer src="/js/signup.js"></script>
+    <script defer type="module" src="/js/signup.js"></script>
   </head>
   <body>
     <header>

--- a/js/module.js
+++ b/js/module.js
@@ -4,7 +4,7 @@ const passwordConfirmInput = document.querySelector('.password-confirm');
 const form = document.querySelector('form');
 const eyeIcons = document.querySelectorAll('.eye-icon');
 
-const emailRegex = new RegExp(/^[a-z\d]+@[a-z]+\.[a-z]{2,}$/);
+const emailRegex = new RegExp(/^[a-z\d]+@[a-z]+\.[a-z]{2,}$/, 'i');
 const passwordRegex = new RegExp(/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/);
 const email = 'test@codeit.com';
 const password = 'codeit101';

--- a/js/module.js
+++ b/js/module.js
@@ -1,0 +1,37 @@
+const emailInput = document.querySelector('.email');
+const passwordInput = document.querySelector('.password');
+const passwordConfirmInput = document.querySelector('.password-confirm');
+const form = document.querySelector('form');
+const eyeIcons = document.querySelectorAll('.eye-icon');
+
+const emailRegex = new RegExp(/^[a-z\d]+@[a-z]+\.[a-z]{2,}$/);
+const passwordRegex = new RegExp(/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/);
+const email = 'test@codeit.com';
+const password = 'codeit101';
+
+const editErrorStatus = (element, message='') => {
+  if (message) {
+    element.classList.add('incorrect-input');
+    element.nextElementSibling.textContent = message;
+  } else {
+    element.classList.remove('incorrect-input');
+    element.nextElementSibling.textContent = message;
+  }
+};
+
+const toggleEyeButton = (e) => {
+  const eyeOff = e.target.parentElement.children[0];
+  const eyeOn = e.target.parentElement.children[1];
+  const input = e.target.parentElement.parentElement.parentElement.children[1];
+
+  if (!eyeOff.classList.contains('display-none')) {
+    input.removeAttribute('type');
+  } else {
+    input.setAttribute('type', 'password');
+  }
+
+  eyeOff.classList.toggle('display-none');
+  eyeOn.classList.toggle('display-none');
+}
+
+export { emailInput, passwordInput, passwordConfirmInput, form, eyeIcons, emailRegex, passwordRegex, email, password, editErrorStatus, toggleEyeButton };

--- a/js/signin.js
+++ b/js/signin.js
@@ -4,7 +4,7 @@ const form = document.querySelector('form');
 const eyeButton = document.querySelector('.eye-button');
 const eyeIcon = document.querySelectorAll('.eye-icon');
 
-const correctMailForm = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+let mailRegex = new RegExp('[a-z0-9]+@[a-z]+\.[a-z]{2,}');
 const correctMail = 'test@codeit.com';
 const correctPassword = 'codeit101';
 
@@ -21,7 +21,7 @@ const editErrorStatus = (element, message='') => {
 const checkEmailInput = (e) => {
   if (!e.target.value) {
     editErrorStatus(e.target, '이메일을 입력해주세요.');
-  } else if (!correctMailForm.test(e.target.value)) {
+  } else if (!mailRegex.test(e.target.value)) {
     editErrorStatus(e.target, '올바른 이메일 주소가 아닙니다.');
   } else {
     editErrorStatus(e.target);
@@ -38,7 +38,7 @@ const checkPasswordInput = (e) => {
 
 const trySignIn = (e) => {
   e.preventDefault();
-  
+
   if (emailInput.value === correctMail && passwordInput.value === correctPassword) {
     location.href = '/html/folder.html';
   } else {

--- a/js/signin.js
+++ b/js/signin.js
@@ -37,10 +37,11 @@ const checkPasswordInput = (e) => {
 }
 
 const trySignIn = (e) => {
+  e.preventDefault();
+  
   if (emailInput.value === correctMail && passwordInput.value === correctPassword) {
     location.href = '/html/folder.html';
   } else {
-    e.preventDefault();
     editErrorStatus(emailInput, '이메일을 확인해주세요.');
     editErrorStatus(passwordInput, '비밀번호를 확인해주세요.');
   }

--- a/js/signin.js
+++ b/js/signin.js
@@ -1,21 +1,14 @@
-const emailInput = document.querySelector('.email');
-const passwordInput = document.querySelector('.password');
-const form = document.querySelector('form');
-const eyeIcons = document.querySelectorAll('.eye-icon');
-
-const emailRegex = new RegExp('^[a-z\d]+@[a-z]+\.[a-z]{2,}$');
-const correctMail = 'test@codeit.com';
-const correctPassword = 'codeit101';
-
-const editErrorStatus = (element, message='') => {
-  if (message) {
-    element.classList.add('incorrect-input');
-    element.nextElementSibling.textContent = message;
-  } else {
-    element.classList.remove('incorrect-input');
-    element.nextElementSibling.textContent = message;
-  }
-}
+import {
+  emailInput,
+  passwordInput,
+  form,
+  eyeIcons,
+  emailRegex,
+  email as correctEmail,
+  password as correctPassword,
+  editErrorStatus,
+  toggleEyeButton
+} from '/js/module.js';
 
 const checkEmailInput = (e) => {
   if (!e.target.value) {
@@ -38,27 +31,12 @@ const checkPasswordInput = (e) => {
 const trySignIn = (e) => {
   e.preventDefault();
 
-  if (emailInput.value === correctMail && passwordInput.value === correctPassword) {
+  if (emailInput.value === correctEmail && passwordInput.value === correctPassword) {
     location.href = '/html/folder.html';
   } else {
     editErrorStatus(emailInput, '이메일을 확인해주세요.');
     editErrorStatus(passwordInput, '비밀번호를 확인해주세요.');
   }
-}
-
-const toggleEyeButton = (e) => {
-  const eyeOff = e.target.parentElement.children[0];
-  const eyeOn = e.target.parentElement.children[1];
-  const input = e.target.parentElement.parentElement.parentElement.children[1];
-
-  if (!eyeOff.classList.contains('display-none')) {
-    input.removeAttribute('type');
-  } else {
-    input.setAttribute('type', 'password');
-  }
-
-  eyeOff.classList.toggle('display-none');
-  eyeOn.classList.toggle('display-none');
 }
 
 emailInput.addEventListener('focusout', checkEmailInput);

--- a/js/signin.js
+++ b/js/signin.js
@@ -4,7 +4,7 @@ const form = document.querySelector('form');
 const eyeButton = document.querySelector('.eye-button');
 const eyeIcon = document.querySelectorAll('.eye-icon');
 
-let mailRegex = new RegExp('[a-z0-9]+@[a-z]+\.[a-z]{2,}');
+const emailRegex = new RegExp('^[a-z\d]+@[a-z]+\.[a-z]{2,}$');
 const correctMail = 'test@codeit.com';
 const correctPassword = 'codeit101';
 
@@ -21,7 +21,7 @@ const editErrorStatus = (element, message='') => {
 const checkEmailInput = (e) => {
   if (!e.target.value) {
     editErrorStatus(e.target, '이메일을 입력해주세요.');
-  } else if (!mailRegex.test(e.target.value)) {
+  } else if (!emailRegex.test(e.target.value)) {
     editErrorStatus(e.target, '올바른 이메일 주소가 아닙니다.');
   } else {
     editErrorStatus(e.target);

--- a/js/signin.js
+++ b/js/signin.js
@@ -1,8 +1,7 @@
 const emailInput = document.querySelector('.email');
 const passwordInput = document.querySelector('.password');
 const form = document.querySelector('form');
-const eyeButton = document.querySelector('.eye-button');
-const eyeIcon = document.querySelectorAll('.eye-icon');
+const eyeIcons = document.querySelectorAll('.eye-icon');
 
 const emailRegex = new RegExp('^[a-z\d]+@[a-z]+\.[a-z]{2,}$');
 const correctMail = 'test@codeit.com';
@@ -47,18 +46,24 @@ const trySignIn = (e) => {
   }
 }
 
-const toggleEyeButton = () => {
-  if (!eyeIcon[0].classList.contains('off')) { // 비밀번호 표시 off인 경우
-    passwordInput.removeAttribute('type'); // {type:"password"} 속성 제거
-  } else { // 비밀번호 표시 on인 경우
-    passwordInput.setAttribute('type', 'password'); // {type: "password"} 속성 추가
+const toggleEyeButton = (e) => {
+  const eyeOff = e.target.parentElement.children[0];
+  const eyeOn = e.target.parentElement.children[1];
+  const input = e.target.parentElement.parentElement.parentElement.children[1];
+
+  if (!eyeOff.classList.contains('display-none')) {
+    input.removeAttribute('type');
+  } else {
+    input.setAttribute('type', 'password');
   }
 
-  eyeIcon[0].classList.toggle('off');
-  eyeIcon[1].classList.toggle('off');
+  eyeOff.classList.toggle('display-none');
+  eyeOn.classList.toggle('display-none');
 }
 
 emailInput.addEventListener('focusout', checkEmailInput);
 passwordInput.addEventListener('focusout', checkPasswordInput);
 form.addEventListener('submit', trySignIn);
-eyeButton.addEventListener('click', toggleEyeButton);
+for (let el of eyeIcons) {
+  el.addEventListener('click', toggleEyeButton);
+}

--- a/js/signin.js
+++ b/js/signin.js
@@ -8,7 +8,7 @@ const correctMailForm = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
 const correctMail = 'test@codeit.com';
 const correctPassword = 'codeit101';
 
-function editErrorStatus(element, message='') {
+const editErrorStatus = (element, message='') => {
   if (message) {
     element.classList.add('incorrect-input');
     element.nextElementSibling.textContent = message;
@@ -18,7 +18,7 @@ function editErrorStatus(element, message='') {
   }
 }
 
-function checkEmailInput(e) {
+const checkEmailInput = (e) => {
   if (!e.target.value) {
     editErrorStatus(e.target, '이메일을 입력해주세요.');
   } else if (!correctMailForm.test(e.target.value)) {
@@ -28,7 +28,7 @@ function checkEmailInput(e) {
   }
 }
 
-function checkPasswordInput(e) {
+const checkPasswordInput = (e) => {
   if (!e.target.value) {
     editErrorStatus(e.target, '비밀번호를 입력해주세요.');
   } else {
@@ -36,7 +36,7 @@ function checkPasswordInput(e) {
   }
 }
 
-function trySignIn(e) {
+const trySignIn = (e) => {
   if (emailInput.value === correctMail && passwordInput.value === correctPassword) {
     location.href = '/html/folder.html';
   } else {
@@ -46,7 +46,7 @@ function trySignIn(e) {
   }
 }
 
-function toggleEyeButton() {
+const toggleEyeButton = () => {
   if (!eyeIcon[0].classList.contains('off')) { // 비밀번호 표시 off인 경우
     passwordInput.removeAttribute('type'); // {type:"password"} 속성 제거
   } else { // 비밀번호 표시 on인 경우

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,30 +1,22 @@
-const emailInput = document.querySelector('.email');
-const passwordInput = document.querySelector('.password');
-const passwordConfirmInput = document.querySelector('.password-confirm');
-const form = document.querySelector('form');
-const eyeIcons = document.querySelectorAll('.eye-icon');
-
-const emailRegex = new RegExp(/^[a-z\d]+@[a-z]+\.[a-z]{2,}$/);
-const passwordRegex = new RegExp(/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/);
-const correctMail = 'test@codeit.com';
-const correctPassword = 'codeit101';
-
-const editErrorStatus = (element, message='') => {
-  if (message) {
-    element.classList.add('incorrect-input');
-    element.nextElementSibling.textContent = message;
-  } else {
-    element.classList.remove('incorrect-input');
-    element.nextElementSibling.textContent = message;
-  }
-};
+import {
+  emailInput,
+  passwordInput,
+  passwordConfirmInput,
+  form,
+  eyeIcons,
+  emailRegex,
+  passwordRegex,
+  email as existingEmail,
+  editErrorStatus,
+  toggleEyeButton
+} from '/js/module.js';
 
 const checkEmail = (email) => {
   if (!email) {
     editErrorStatus(emailInput, '이메일을 입력해주세요.');
   } else if (!emailRegex.test(email)) {
     editErrorStatus(emailInput, '올바른 이메일 주소가 아닙니다.');
-  } else if (email === correctMail) {
+  } else if (email === existingEmail) {
     editErrorStatus(emailInput, '이미 사용 중인 이메일입니다.');
   } else {
     editErrorStatus(emailInput);
@@ -70,21 +62,6 @@ const trySignUp = (e) => {
     checkPasswordConfirm(passwordConfirmInput);
   }
 };
-
-const toggleEyeButton = (e) => {
-  const eyeOff = e.target.parentElement.children[0];
-  const eyeOn = e.target.parentElement.children[1];
-  const input = e.target.parentElement.parentElement.parentElement.children[1];
-
-  if (!eyeOff.classList.contains('display-none')) {
-    input.removeAttribute('type');
-  } else {
-    input.setAttribute('type', 'password');
-  }
-
-  eyeOff.classList.toggle('display-none');
-  eyeOn.classList.toggle('display-none');
-}
 
 emailInput.addEventListener('focusout', checkEmailInput);
 passwordInput.addEventListener('focusout', checkPasswordInput);

--- a/js/signup.js
+++ b/js/signup.js
@@ -20,32 +20,44 @@ const editErrorStatus = (element, message='') => {
   }
 };
 
-const checkEmailInput = (e) => {
-  if (!e.target.value) {
-    editErrorStatus(e.target, '이메일을 입력해주세요.');
-  } else if (!emailRegex.test(e.target.value)) {
-    editErrorStatus(e.target, '올바른 이메일 주소가 아닙니다.');
-  } else if (e.target.value === correctMail) {
-    editErrorStatus(e.target, '이미 사용 중인 이메일입니다.');
+const checkEmail = (email) => {
+  if (!email) {
+    editErrorStatus(emailInput, '이메일을 입력해주세요.');
+  } else if (!emailRegex.test(email)) {
+    editErrorStatus(emailInput, '올바른 이메일 주소가 아닙니다.');
+  } else if (email === correctMail) {
+    editErrorStatus(emailInput, '이미 사용 중인 이메일입니다.');
   } else {
-    editErrorStatus(e.target);
+    editErrorStatus(emailInput);
   }
+};
+
+const checkPassword = (password) => {
+  if (!passwordRegex.test(password)) {
+    editErrorStatus(passwordInput, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.');
+  } else {
+    editErrorStatus(passwordInput);
+  }
+};
+
+const checkPasswordConfirm = (password) => {
+  if (password !== passwordInput.value) {
+    editErrorStatus(passwordConfirmInput, '비밀번호가 일치하지 않아요.');
+  } else {
+    editErrorStatus(passwordConfirmInput);
+  }
+};
+
+const checkEmailInput = (e) => {
+  checkEmail(e.target.value);
 };
 
 const checkPasswordInput = (e) => {
-  if (!passwordRegex.test(e.target.value)) {
-    editErrorStatus(e.target, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.');
-  } else {
-    editErrorStatus(e.target);
-  }
+  checkPassword(e.target.value);
 };
 
 const checkPasswordConfirmInput = (e) => {
-  if (e.target.value !== passwordInput.value) {
-    editErrorStatus(e.target, '비밀번호가 일치하지 않아요.');
-  } else {
-    editErrorStatus(e.target);
-  }
+  checkPasswordConfirm(e.target.value);
 };
 
 const trySignUp = (e) => {
@@ -54,19 +66,9 @@ const trySignUp = (e) => {
   if (emailRegex.test(emailInput.value) && passwordRegex.test(passwordInput.value) && passwordConfirmInput.value === passwordInput.value) {
     location.href = '/html/folder.html';
   } else {
-      if (!emailInput.value) {
-        editErrorStatus(emailInput, '이메일을 입력해주세요.');
-      } else if (!emailRegex.test(emailInput.value)) {
-        editErrorStatus(emailInput, '올바른 이메일 주소가 아닙니다.');
-      } else if (e.target.value === correctMail) {
-        editErrorStatus(emailInput, '이미 사용 중인 이메일입니다.');
-      }
-      if (!passwordRegex.test(passwordInput.value)) {
-        editErrorStatus(passwordInput, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.');
-      }
-      if (passwordConfirmInput.value !== passwordInput.value) {
-        editErrorStatus(passwordConfirmInput, '비밀번호가 일치하지 않아요.');
-      }
+    checkEmail(emailInput);
+    checkPassword(passwordInput);
+    checkPasswordConfirm(passwordConfirmInput);
   }
 };
 

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,0 +1,88 @@
+const emailInput = document.querySelector('.email');
+const passwordInput = document.querySelector('.password');
+const passwordConfirmInput = document.querySelector('.password-confirm');
+const form = document.querySelector('form');
+const eyeButton = document.querySelector('.eye-button');
+const eyeIcon = document.querySelectorAll('.eye-icon');
+
+const emailRegex = new RegExp(/^[a-z\d]+@[a-z]+\.[a-z]{2,}$/);
+const passwordRegex = new RegExp(/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/);
+const correctMail = 'test@codeit.com';
+const correctPassword = 'codeit101';
+
+const editErrorStatus = (element, message='') => {
+  if (message) {
+    element.classList.add('incorrect-input');
+    element.nextElementSibling.textContent = message;
+  } else {
+    element.classList.remove('incorrect-input');
+    element.nextElementSibling.textContent = message;
+  }
+};
+
+const checkEmailInput = (e) => {
+  if (!e.target.value) {
+    editErrorStatus(e.target, '이메일을 입력해주세요.');
+  } else if (!emailRegex.test(e.target.value)) {
+    editErrorStatus(e.target, '올바른 이메일 주소가 아닙니다.');
+  } else if (e.target.value === correctMail) {
+    editErrorStatus(e.target, '이미 사용 중인 이메일입니다.');
+  } else {
+    editErrorStatus(e.target);
+  }
+};
+
+const checkPasswordInput = (e) => {
+  if (!passwordRegex.test(e.target.value)) {
+    editErrorStatus(e.target, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.');
+  } else {
+    editErrorStatus(e.target);
+  }
+};
+
+const checkPasswordConfirmInput = (e) => {
+  if (e.target.value !== passwordInput.value) {
+    editErrorStatus(e.target, '비밀번호가 일치하지 않아요.');
+  } else {
+    editErrorStatus(e.target);
+  }
+};
+
+const trySignUp = (e) => {
+  e.preventDefault();
+
+  if (emailRegex.test(emailInput.value) && passwordRegex.test(passwordInput.value) && passwordConfirmInput.value === passwordInput.value) {
+    location.href = '/html/folder.html';
+  } else {
+      if (!emailInput.value) {
+        editErrorStatus(emailInput, '이메일을 입력해주세요.');
+      } else if (!emailRegex.test(emailInput.value)) {
+        editErrorStatus(emailInput, '올바른 이메일 주소가 아닙니다.');
+      } else if (e.target.value === correctMail) {
+        editErrorStatus(emailInput, '이미 사용 중인 이메일입니다.');
+      }
+      if (!passwordRegex.test(passwordInput.value)) {
+        editErrorStatus(passwordInput, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.');
+      }
+      if (passwordConfirmInput.value !== passwordInput.value) {
+        editErrorStatus(passwordConfirmInput, '비밀번호가 일치하지 않아요.');
+      }
+  }
+};
+
+const toggleEyeButton = () => {
+  if (!eyeIcon[0].classList.contains('off')) { // 비밀번호 표시 off인 경우
+    passwordInput.removeAttribute('type'); // {type:"password"} 속성 제거
+  } else { // 비밀번호 표시 on인 경우
+    passwordInput.setAttribute('type', 'password'); // {type: "password"} 속성 추가
+  }
+
+  eyeIcon[0].classList.toggle('off');
+  eyeIcon[1].classList.toggle('off');
+};
+
+emailInput.addEventListener('focusout', checkEmailInput);
+passwordInput.addEventListener('focusout', checkPasswordInput);
+passwordConfirmInput.addEventListener('focusout', checkPasswordConfirmInput)
+form.addEventListener('submit', trySignUp);
+eyeButton.addEventListener('click', toggleEyeButton);

--- a/js/signup.js
+++ b/js/signup.js
@@ -2,8 +2,7 @@ const emailInput = document.querySelector('.email');
 const passwordInput = document.querySelector('.password');
 const passwordConfirmInput = document.querySelector('.password-confirm');
 const form = document.querySelector('form');
-const eyeButton = document.querySelector('.eye-button');
-const eyeIcon = document.querySelectorAll('.eye-icon');
+const eyeIcons = document.querySelectorAll('.eye-icon');
 
 const emailRegex = new RegExp(/^[a-z\d]+@[a-z]+\.[a-z]{2,}$/);
 const passwordRegex = new RegExp(/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/);
@@ -72,19 +71,25 @@ const trySignUp = (e) => {
   }
 };
 
-const toggleEyeButton = () => {
-  if (!eyeIcon[0].classList.contains('off')) { // 비밀번호 표시 off인 경우
-    passwordInput.removeAttribute('type'); // {type:"password"} 속성 제거
-  } else { // 비밀번호 표시 on인 경우
-    passwordInput.setAttribute('type', 'password'); // {type: "password"} 속성 추가
+const toggleEyeButton = (e) => {
+  const eyeOff = e.target.parentElement.children[0];
+  const eyeOn = e.target.parentElement.children[1];
+  const input = e.target.parentElement.parentElement.parentElement.children[1];
+
+  if (!eyeOff.classList.contains('display-none')) {
+    input.removeAttribute('type');
+  } else {
+    input.setAttribute('type', 'password');
   }
 
-  eyeIcon[0].classList.toggle('off');
-  eyeIcon[1].classList.toggle('off');
-};
+  eyeOff.classList.toggle('display-none');
+  eyeOn.classList.toggle('display-none');
+}
 
 emailInput.addEventListener('focusout', checkEmailInput);
 passwordInput.addEventListener('focusout', checkPasswordInput);
 passwordConfirmInput.addEventListener('focusout', checkPasswordConfirmInput)
 form.addEventListener('submit', trySignUp);
-eyeButton.addEventListener('click', toggleEyeButton);
+for (let el of eyeIcons) {
+  el.addEventListener('click', toggleEyeButton);
+}

--- a/js/signup.js
+++ b/js/signup.js
@@ -57,9 +57,9 @@ const trySignUp = (e) => {
   if (emailRegex.test(emailInput.value) && passwordRegex.test(passwordInput.value) && passwordConfirmInput.value === passwordInput.value) {
     location.href = '/html/folder.html';
   } else {
-    checkEmail(emailInput);
-    checkPassword(passwordInput);
-    checkPasswordConfirm(passwordConfirmInput);
+    checkEmail(emailInput.value);
+    checkPassword(passwordInput.value);
+    checkPasswordConfirm(passwordConfirmInput.value);
   }
 };
 

--- a/src/sign.css
+++ b/src/sign.css
@@ -100,7 +100,7 @@ input:focus {
   right: 3.1rem;
 }
 
-.off {
+.display-none {
   display: none;
 }
 


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] 이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 수정사항

- 함수 선언 -> 함수 표현식으로 변경
- 로그인 시도 성공 시 정상적으로 페이지 이동하도록 수정
- 이메일 정규식 수정

## 주요 변경사항

- 회원가입 페이지에서의 유효성 검사를 위한 자바스크립트 파일 작성
- 회원가입 submit 이벤트 발생 시 일괄적으로 모든 input의 유효성 검사를 위해 이벤트 콜백 함수에서 분리된 입력값 유효성 검사 함수 작성
- eye-button이 2개 이상일 때도 동작할 수 있도록 일반화
  - toggleEyeButton 함수가 이벤트가 발생한 요소에서 상대적인 위치를 사용해서 동작하도록 수정
  - 클릭한 위치에 따라 이벤트가 발생하는 타겟이 달라지는 것을 막기 위해  `button` 태그가 아니라 `eye-icon` 클래스를 가진 `img` 태그 요소에서 이벤트가 발생하도록 수정
- `signin.js`와 `signup.js`에서 공통적으로 사용하는 변수와 함수 모듈화