### PR TITLE
[손지은] week5

### DIFF
--- a/css/sign.css
+++ b/css/sign.css
@@ -126,7 +126,7 @@ header p{
     fill: white;
     cursor: pointer;
 }
-.email_error_message,.pwd_error_message{
+.err_message{
     display: none;
     color: red;
 }

--- a/html/signin.html
+++ b/html/signin.html
@@ -41,6 +41,6 @@
             </div>
         </div>
     </div>
-    <script type="module" src="/script/sign.js"></script>
+    <script type="module" src="/script/signin.js"></script>
 </body>
 </html>

--- a/html/signin.html
+++ b/html/signin.html
@@ -19,7 +19,7 @@
                 <div class="form__wrapper">
                     <label for="email_input">이메일</label>
                     <input type="email" class="email_input" id="email_input" name="email">
-                    <div class="email_error_message"></div>
+                    <div class="err_message email_error_message"></div>
                 </div>
                 <div class="form__wrapper">
                     <label for="pwd_input">비밀번호</label>
@@ -27,7 +27,7 @@
                         <input type="password" class="pwd_input" id="pwd_input" name="password">
                         <img src="/img/eye-off.svg" alt="" class="password-eye">
                     </div>
-                    <div class="pwd_error_message"></div>
+                    <div class="err_message pwd_error_message"></div>
                 </div>
                 
                 <button class="btn-sign">로그인</button>

--- a/html/signin.html
+++ b/html/signin.html
@@ -18,7 +18,7 @@
             <form action="/folder" method="post" class="form__sign" >
                 <div class="form__wrapper">
                     <label for="email_input">이메일</label>
-                    <input type="email" class="email_input" id="email_input" name="email">
+                    <input class="email_input" id="email_input" name="email">
                     <div class="err_message email_error_message"></div>
                 </div>
                 <div class="form__wrapper">

--- a/html/signin.html
+++ b/html/signin.html
@@ -41,6 +41,6 @@
             </div>
         </div>
     </div>
-    <script src="/script/sign.js"></script>
+    <script type="module" src="/script/sign.js"></script>
 </body>
 </html>

--- a/html/signup.html
+++ b/html/signup.html
@@ -19,7 +19,7 @@
                 <div class="form__wrapper">
                     <label for="email_input">이메일</label>
                     <input type="email" class="email_input" id="email_input" name="email">
-                    <div class="email_error_message"></div>
+                    <div class="err_message email_error_message"></div>
                 </div>
                 <div class="form__wrapper">
                     <label for="pwd_input">비밀번호</label>
@@ -27,7 +27,7 @@
                         <input type="password" class="pwd_input" id="pwd_input" name="password">
                         <img src="/img/eye-off.svg" alt="" class="password-eye test">
                     </div>
-                    <div class="pwd_error_message"></div>
+                    <div class="err_message pwd_error_message"></div>
                 </div>
                 <div class="form__wrapper">
                     <label for="check_pwd_input">비밀번호 확인</label>
@@ -35,7 +35,7 @@
                         <input type="password" class="check_pwd_input" id="check_pwd_input">
                         <img src="/img/eye-off.svg" alt="" class="password-eye">
                     </div>
-                    <div class="check_pwd_error_message"></div>
+                    <div class="err_message check_pwd_error_message"></div>
                 </div>
                 <button class="btn-sign">회원가입</button>
             </form>

--- a/html/signup.html
+++ b/html/signup.html
@@ -25,7 +25,7 @@
                     <label for="pwd_input">비밀번호</label>
                     <div class="form__input-wrapper">
                         <input type="password" class="pwd_input" id="pwd_input" name="password">
-                        <img src="/img/eye-on.svg" alt="" class="password-eye">
+                        <img src="/img/eye-off.svg" alt="" class="password-eye test">
                     </div>
                     <div class="pwd_error_message"></div>
                 </div>
@@ -33,7 +33,7 @@
                     <label for="check_pwd_input">비밀번호 확인</label>
                     <div class="form__input-wrapper">
                         <input type="password" class="check_pwd_input" id="check_pwd_input">
-                        <img src="/img/eye-on.svg" alt="" class="password-eye">
+                        <img src="/img/eye-off.svg" alt="" class="password-eye">
                     </div>
                     <div class="check_pwd_error_message"></div>
                 </div>
@@ -46,8 +46,8 @@
                     <a href="https://www.kakaocorp.com/page/"><img src="/img/kakaoicon.png" alt=""></a>
                 </div>
             </div>
-        </div>
+        </div>  
     </div>
-    <script src="/script/sign.js"></script>
+    <script type="module" src="/script/signup.js"></script>
 </body>
 </html>

--- a/html/signup.html
+++ b/html/signup.html
@@ -15,10 +15,10 @@
             <p>이미 회원이신가요?<a href="/html/signin.html" class="header__sign-link">로그인 하기</a></p>
         </header>
         <div class="container">
-            <form action="post" class="form__sign">
+            <form action="/folder" class="form__sign">
                 <div class="form__wrapper">
                     <label for="email_input">이메일</label>
-                    <input type="email" class="email_input" id="email_input" name="email">
+                    <input class="email_input" id="email_input" name="email">
                     <div class="err_message email_error_message"></div>
                 </div>
                 <div class="form__wrapper">

--- a/html/signup.html
+++ b/html/signup.html
@@ -19,6 +19,7 @@
                 <div class="form__wrapper">
                     <label for="email_input">이메일</label>
                     <input type="email" class="email_input" id="email_input" name="email">
+                    <div class="email_error_message"></div>
                 </div>
                 <div class="form__wrapper">
                     <label for="pwd_input">비밀번호</label>
@@ -26,6 +27,7 @@
                         <input type="password" class="pwd_input" id="pwd_input" name="password">
                         <img src="/img/eye-on.svg" alt="" class="password-eye">
                     </div>
+                    <div class="pwd_error_message"></div>
                 </div>
                 <div class="form__wrapper">
                     <label for="check_pwd_input">비밀번호 확인</label>
@@ -33,6 +35,7 @@
                         <input type="password" class="check_pwd_input" id="check_pwd_input">
                         <img src="/img/eye-on.svg" alt="" class="password-eye">
                     </div>
+                    <div class="check_pwd_error_message"></div>
                 </div>
                 <button class="btn-sign">회원가입</button>
             </form>
@@ -45,5 +48,6 @@
             </div>
         </div>
     </div>
+    <script src="/script/sign.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,14 +6,14 @@
     <!-- sns 미리보기 -->
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://stellar-gecko-8bf6ce.netlify.app/" />
+    <meta property="og:url" content="https://jieun-linkbrary.netlify.app" />
     <meta property="og:title" content="Linkbrary" />
     <meta property="og:description" content="세상의 모든 정보를 쉽게 저장하고 관리해 보세요" />
     <meta property="og:image" content="img/meta.png" />
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content="https://stellar-gecko-8bf6ce.netlify.app/" />
+    <meta property="twitter:url" content="https://jieun-linkbrary.netlify.app" />
     <meta property="twitter:title" content="Linkbrary" />
     <meta property="twitter:description" content="세상의 모든 정보를 쉽게 저장하고 관리해 보세요" />
     <meta property="twitter:image" content="img/meta.png" />

--- a/script/sign.js
+++ b/script/sign.js
@@ -56,9 +56,9 @@ function signinValidCheck(e){
         e.preventDefault();
     }
 }
-$signBtn.addEventListener('click',signinValidCheck);
+document.querySelector('.form__sign').addEventListener('submit',signinValidCheck);
 
-let eyeOn = $pwdEye.src.includes('eye-on');;
+let eyeOn = $pwdEye.src.includes('eye-on');
 function pwdEyeOnOff(e){
     eyeOn = !eyeOn;
     if(eyeOn){
@@ -70,4 +70,4 @@ function pwdEyeOnOff(e){
         $pwd.type ="password";
     }
 }
-$pwdEye.addEventListener('submit',pwdEyeOnOff);
+$pwdEye.addEventListener('click',pwdEyeOnOff);

--- a/script/sign.js
+++ b/script/sign.js
@@ -69,4 +69,4 @@ function pwdEyeOnOff(e){
         $pwd.type ="password";
     }
 }
-$pwdEye.addEventListener('click',pwdEyeOnOff);
+$pwdEye.addEventListener('submit',pwdEyeOnOff);

--- a/script/sign.js
+++ b/script/sign.js
@@ -2,7 +2,7 @@ const $emailErrorMessage = document.querySelector('.email_error_message');
 const $pwdErrorMessage = document.querySelector('.pwd_error_message');
 const $email = document.querySelector('.email_input');
 const $pwd = document.querySelector('.pwd_input');
-const $signBtn = document.querySelector('.btn-sign');
+const $submit = document.querySelector('.form__sign');
 const $pwdEye = document.querySelectorAll('.password-eye');
 
 let emailValid = false;
@@ -11,12 +11,12 @@ let pwdValid = false;
 const REGEMAIL = /^[A-Za-z0-9\-]+@[A-Za-z0-9]+\.[a-z]/;
 function emailErrorMessage(e){
     emailValid = false;
-    if(e.target.value === ""){
+    if($email.value === ""){
         $emailErrorMessage.textContent = "이메일을 입력해주세요."
         $emailErrorMessage.style.display ="block";
         $email.classList.add('border-red');
     }
-   else if(!REGEMAIL.test(e.target.value)){
+   else if(!REGEMAIL.test($email.value)){
         $emailErrorMessage.textContent = "올바른 이메일 주소가 아닙니다."
         $emailErrorMessage.style.display ="block";
         $email.classList.add('border-red');
@@ -32,7 +32,7 @@ $email.addEventListener("focusout",emailErrorMessage);
 
 function pwdErrorMessage(e){
     pwdValid=false;
-    if(e.target.value === ""){
+    if($pwd.value === ""){
         $pwdErrorMessage.textContent = "비밀번호를 입력해주세요."
         $pwdErrorMessage.style.display ="block";
         $pwd.classList.add('border-red');
@@ -46,9 +46,11 @@ function pwdErrorMessage(e){
 $pwd.addEventListener("focusout",pwdErrorMessage);
 
 function signinValidCheck(e){
+    if(emailValid && pwdValid){
+        return;
+    }
     if(!emailValid){
         $emailErrorMessage.textContent = "이메일을 확인해주세요."
-        $emailErrorMessage.style.display ="block";
         e.preventDefault();
     }
     if(!pwdValid){
@@ -57,7 +59,10 @@ function signinValidCheck(e){
         e.preventDefault();
     }
 }
-document.querySelector('.form__sign').addEventListener('submit',signinValidCheck);
+$submit.addEventListener('submit',signinValidCheck);
+$submit.addEventListener('submit',pwdErrorMessage);
+$submit.addEventListener('submit',emailErrorMessage);
+
 
 function pwdEyeOnOff(e){
     let eyeOn = e.target.src.includes('eye-on');

--- a/script/sign.js
+++ b/script/sign.js
@@ -57,7 +57,7 @@ function signinValidCheck(e){
 }
 $signBtn.addEventListener('click',signinValidCheck);
 
-let eyeOn = false;
+let eyeOn = $pwdEye.src.includes('eye-on');;
 function pwdEyeOnOff(e){
     eyeOn = !eyeOn;
     if(eyeOn){

--- a/script/sign.js
+++ b/script/sign.js
@@ -8,6 +8,7 @@ const $pwdEye = document.querySelector('.password-eye');
 let emailValid = false;
 let pwdValid = false;
 
+const REGEMAIL = /^[A-Za-z0-9\-]+@[A-Za-z0-9]+\.[a-z]/;
 function emailErrorMessage(e){
     emailValid = false;
     if(e.target.value === ""){
@@ -15,7 +16,7 @@ function emailErrorMessage(e){
         $emailErrorMessage.style.display ="block";
         $email.classList.add('border-red');
     }
-   else if(!e.target.value.includes('@')){
+   else if(!REGEMAIL.test(e.target.value)){
         $emailErrorMessage.textContent = "올바른 이메일 주소가 아닙니다."
         $emailErrorMessage.style.display ="block";
         $email.classList.add('border-red');

--- a/script/sign.js
+++ b/script/sign.js
@@ -77,4 +77,4 @@ function pwdEyeOnOff(e){
 }
 $pwdEye[0].addEventListener('click',pwdEyeOnOff);
 
-export {$email,$emailErrorMessage,$pwdErrorMessage,$pwd,pwdEyeOnOff,$pwdEye}
+export {$email,$emailErrorMessage,$pwdErrorMessage,$pwd,pwdEyeOnOff,$pwdEye,emailValid,emailErrorMessage}

--- a/script/sign.js
+++ b/script/sign.js
@@ -2,14 +2,13 @@ const $emailErrorMessage = document.querySelector('.email_error_message');
 const $pwdErrorMessage = document.querySelector('.pwd_error_message');
 const $email = document.querySelector('.email_input');
 const $pwd = document.querySelector('.pwd_input');
-const $submit = document.querySelector('.form__sign');
 const $pwdEye = document.querySelectorAll('.password-eye');
 
 let emailValid = false;
 let pwdValid = false;
 
 const REGEMAIL = /^[A-Za-z0-9\-]+@[A-Za-z0-9]+\.[a-z]/;
-function emailErrorMessage(e){
+function emailErrorMessage(){
     emailValid = false;
     if($email.value === ""){
         $emailErrorMessage.textContent = "이메일을 입력해주세요."
@@ -30,7 +29,7 @@ function emailErrorMessage(e){
 $email.addEventListener("focusout",emailErrorMessage);
 
 
-function pwdErrorMessage(e){
+function pwdErrorMessage(){
     pwdValid=false;
     if($pwd.value === ""){
         $pwdErrorMessage.textContent = "비밀번호를 입력해주세요."
@@ -45,25 +44,6 @@ function pwdErrorMessage(e){
 }
 $pwd.addEventListener("focusout",pwdErrorMessage);
 
-function signinValidCheck(e){
-    if(emailValid && pwdValid){
-        return;
-    }
-    if(!emailValid){
-        $emailErrorMessage.textContent = "이메일을 확인해주세요."
-        e.preventDefault();
-    }
-    if(!pwdValid){
-        $pwdErrorMessage.textContent = "비밀번호를 확인해주세요."
-        $pwdErrorMessage.style.display ="block";
-        e.preventDefault();
-    }
-}
-$submit.addEventListener('submit',signinValidCheck);
-$submit.addEventListener('submit',pwdErrorMessage);
-$submit.addEventListener('submit',emailErrorMessage);
-
-
 function pwdEyeOnOff(e){
     let eyeOn = e.target.src.includes('eye-on');
     if(eyeOn){
@@ -77,4 +57,4 @@ function pwdEyeOnOff(e){
 }
 $pwdEye[0].addEventListener('click',pwdEyeOnOff);
 
-export {$email,$emailErrorMessage,$pwdErrorMessage,$pwd,pwdEyeOnOff,$pwdEye,emailValid,emailErrorMessage}
+export {$email,$emailErrorMessage,$pwdErrorMessage,$pwd,pwdEyeOnOff,$pwdEye,emailValid,pwdValid,emailErrorMessage,pwdErrorMessage}

--- a/script/sign.js
+++ b/script/sign.js
@@ -3,7 +3,7 @@ const $pwdErrorMessage = document.querySelector('.pwd_error_message');
 const $email = document.querySelector('.email_input');
 const $pwd = document.querySelector('.pwd_input');
 const $signBtn = document.querySelector('.btn-sign');
-const $pwdEye = document.querySelector('.password-eye');
+const $pwdEye = document.querySelectorAll('.password-eye');
 
 let emailValid = false;
 let pwdValid = false;
@@ -27,6 +27,8 @@ function emailErrorMessage(e){
     emailValid = true;
    }
 }
+$email.addEventListener("focusout",emailErrorMessage);
+
 
 function pwdErrorMessage(e){
     pwdValid=false;
@@ -41,7 +43,6 @@ function pwdErrorMessage(e){
         pwdValid = true;
     }
 }
-$email.addEventListener("focusout",emailErrorMessage);
 $pwd.addEventListener("focusout",pwdErrorMessage);
 
 function signinValidCheck(e){
@@ -58,16 +59,17 @@ function signinValidCheck(e){
 }
 document.querySelector('.form__sign').addEventListener('submit',signinValidCheck);
 
-let eyeOn = $pwdEye.src.includes('eye-on');
 function pwdEyeOnOff(e){
-    eyeOn = !eyeOn;
+    let eyeOn = e.target.src.includes('eye-on');
     if(eyeOn){
-        e.target.src = "/img/eye-on.svg";
-        $pwd.type ="text";
+        e.target.src = "/img/eye-off.svg";
+        e.target.previousElementSibling.type ="password";
     }
     else{
-        e.target.src = "/img/eye-off.svg";
-        $pwd.type ="password";
+        e.target.src = "/img/eye-on.svg";
+        e.target.previousElementSibling.type ="text";
     }
 }
-$pwdEye.addEventListener('click',pwdEyeOnOff);
+$pwdEye[0].addEventListener('click',pwdEyeOnOff);
+
+export {$email,$emailErrorMessage,$pwdErrorMessage,$pwd,pwdEyeOnOff,$pwdEye}

--- a/script/signin.js
+++ b/script/signin.js
@@ -1,0 +1,20 @@
+import {$emailErrorMessage,$pwdErrorMessage,pwdErrorMessage,emailValid,pwdValid, emailErrorMessage} from './sign.js';
+
+const $submit = document.querySelector('.form__sign');
+function signinValidCheck(e){
+    if(emailValid && pwdValid){
+        return;
+    }
+    if(!emailValid){
+        $emailErrorMessage.textContent = "이메일을 확인해주세요."
+        e.preventDefault();
+    }
+    if(!pwdValid){
+        $pwdErrorMessage.textContent = "비밀번호를 확인해주세요."
+        $pwdErrorMessage.style.display ="block";
+        e.preventDefault();
+    }
+}
+$submit.addEventListener('submit',signinValidCheck);
+$submit.addEventListener('submit',pwdErrorMessage);
+$submit.addEventListener('submit',emailErrorMessage);

--- a/script/signup.js
+++ b/script/signup.js
@@ -1,0 +1,72 @@
+const $pwdErrorMessage = document.querySelector('.pwd_error_message');
+
+const $pwd = document.querySelector('.pwd_input');
+const $signBtn = document.querySelector('.btn-sign');
+const $pwdEye = document.querySelector('.password-eye');
+
+let emailValid = false;
+let pwdValid = false;
+
+const REGEMAIL = /^[A-Za-z0-9\-]+@[A-Za-z0-9]+\.[a-z]/;
+function emailErrorMessage(e){
+    emailValid = false;
+    if(e.target.value === ""){
+        $emailErrorMessage.textContent = "이메일을 입력해주세요."
+        $emailErrorMessage.style.display ="block";
+        $email.classList.add('border-red');
+    }
+   else if(!REGEMAIL.test(e.target.value)){
+        $emailErrorMessage.textContent = "올바른 이메일 주소가 아닙니다."
+        $emailErrorMessage.style.display ="block";
+        $email.classList.add('border-red');
+   }
+   else{
+    $emailErrorMessage.style.display ="none";
+    $email.classList.remove("border-red");
+    emailValid = true;
+   }
+}
+
+function pwdErrorMessage(e){
+    pwdValid=false;
+    if(e.target.value === ""){
+        $pwdErrorMessage.textContent = "비밀번호를 입력해주세요."
+        $pwdErrorMessage.style.display ="block";
+        $pwd.classList.add('border-red');
+    }
+    else{
+        $pwdErrorMessage.style.display ="none";
+        $pwd.classList.remove("border-red");
+        pwdValid = true;
+    }
+}
+$email.addEventListener("focusout",emailErrorMessage);
+$pwd.addEventListener("focusout",pwdErrorMessage);
+
+function signinValidCheck(e){
+    if(!emailValid){
+        $emailErrorMessage.textContent = "이메일을 확인해주세요."
+        $emailErrorMessage.style.display ="block";
+        e.preventDefault();
+    }
+    if(!pwdValid){
+        $pwdErrorMessage.textContent = "비밀번호를 확인해주세요."
+        $pwdErrorMessage.style.display ="block";
+        e.preventDefault();
+    }
+}
+document.querySelector('.form__sign').addEventListener('submit',signinValidCheck);
+
+let eyeOn = $pwdEye.src.includes('eye-on');
+function pwdEyeOnOff(e){
+    eyeOn = !eyeOn;
+    if(eyeOn){
+        e.target.src = "/img/eye-on.svg";
+        $pwd.type ="text";
+    }
+    else{
+        e.target.src = "/img/eye-off.svg";
+        $pwd.type ="password";
+    }
+}
+$pwdEye.addEventListener('click',pwdEyeOnOff);

--- a/script/signup.js
+++ b/script/signup.js
@@ -1,7 +1,10 @@
-import {$email,$emailErrorMessage,$pwdErrorMessage,$pwd,pwdEyeOnOff,$pwdEye} from './sign.js';
+import {$email,$emailErrorMessage,$pwdErrorMessage,$pwd,pwdEyeOnOff,$pwdEye,emailValid, emailErrorMessage} from './sign.js';
+
 const $pwdCheckErrorMessage = document.querySelector('.check_pwd_error_message');
 const $pwdCheck = document.querySelector('.check_pwd_input');
+const $submit = document.querySelector('.form__sign');
 
+let emailDupliValid = false;
 function emailDuplication(){
     const existEmail = 'test@codeit.com'
     if($email.value === existEmail){
@@ -9,25 +12,32 @@ function emailDuplication(){
         $emailErrorMessage.style.display ="block";
         $email.classList.add('border-red');
     }
+    else
+        emailDupliValid = true;
 }
 $email.addEventListener("focusout", emailDuplication);
 
-const REGPWD = /[0-9][a-zA-Z].{8,}/;
+const REGPWD = /(?=.*[a-zA-Z])(?=.*[0-9]){8,}/;
+let pwdValid = false;
 function pwdValidation(){
     if(!REGPWD.test($pwd.value)){
         $pwdErrorMessage.textContent = "비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요."
         $pwdErrorMessage.style.display ="block";
         $pwd.classList.add('border-red');
     }
+    else
+        pwdValid = true;
 }
 $pwd.addEventListener("focusout", pwdValidation);
 
 $pwdEye[1].addEventListener('click',pwdEyeOnOff);
 
+let pwdCheckValid = false;
 function pwdCheck(){
     if($pwdCheck.value === $pwd.value){
         $pwdCheckErrorMessage.style.display ="none";
         $pwdCheck.classList.remove('border-red');
+        pwdCheckValid=true;
     }
     else{
         $pwdCheckErrorMessage.textContent = "비밀번호가 일치하지 않아요."
@@ -35,4 +45,16 @@ function pwdCheck(){
         $pwdCheck.classList.add('border-red');
     }
 }
+
 $pwdCheck.addEventListener("focusout", pwdCheck);
+
+function validCheck(e){
+    if(pwdValid && pwdCheckValid && emailValid&&emailDupliValid)
+        return;
+    else
+      e.preventDefault();  
+}
+$submit.addEventListener("submit",validCheck);
+$submit.addEventListener("submit",emailErrorMessage);
+$submit.addEventListener("submit",pwdCheck);
+$submit.addEventListener("submit",pwdValidation);

--- a/script/signup.js
+++ b/script/signup.js
@@ -11,13 +11,14 @@ function emailDuplication(){
         $emailErrorMessage.textContent = "이미 사용 중인 이메일입니다."
         $emailErrorMessage.style.display ="block";
         $email.classList.add('border-red');
+        emailDupliValid = false;
     }
     else
         emailDupliValid = true;
 }
 $email.addEventListener("focusout", emailDuplication);
 
-const REGPWD = /(?=.*[a-zA-Z])(?=.*[0-9]){8,}/;
+const REGPWD = /(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-Z0-9]{8,}/;
 let pwdValid = false;
 function pwdValidation(){
     if(!REGPWD.test($pwd.value)){
@@ -56,5 +57,6 @@ function validCheck(e){
 }
 $submit.addEventListener("submit",validCheck);
 $submit.addEventListener("submit",emailErrorMessage);
+$submit.addEventListener("submit",emailDuplication);
 $submit.addEventListener("submit",pwdCheck);
 $submit.addEventListener("submit",pwdValidation);

--- a/script/signup.js
+++ b/script/signup.js
@@ -44,6 +44,7 @@ function pwdCheck(){
         $pwdCheckErrorMessage.textContent = "비밀번호가 일치하지 않아요."
         $pwdCheckErrorMessage.style.display ="block";
         $pwdCheck.classList.add('border-red');
+        pwdCheckValid=false;
     }
 }
 

--- a/script/signup.js
+++ b/script/signup.js
@@ -1,4 +1,6 @@
 import {$email,$emailErrorMessage,$pwdErrorMessage,$pwd,pwdEyeOnOff,$pwdEye} from './sign.js';
+const $pwdCheckErrorMessage = document.querySelector('.check_pwd_error_message');
+const $pwdCheck = document.querySelector('.check_pwd_input');
 
 function emailDuplication(){
     const existEmail = 'test@codeit.com'
@@ -21,3 +23,16 @@ function pwdValidation(){
 $pwd.addEventListener("focusout", pwdValidation);
 
 $pwdEye[1].addEventListener('click',pwdEyeOnOff);
+
+function pwdCheck(){
+    if($pwdCheck.value === $pwd.value){
+        $pwdCheckErrorMessage.style.display ="none";
+        $pwdCheck.classList.remove('border-red');
+    }
+    else{
+        $pwdCheckErrorMessage.textContent = "비밀번호가 일치하지 않아요."
+        $pwdCheckErrorMessage.style.display ="block";
+        $pwdCheck.classList.add('border-red');
+    }
+}
+$pwdCheck.addEventListener("focusout", pwdCheck);

--- a/script/signup.js
+++ b/script/signup.js
@@ -1,72 +1,23 @@
-const $pwdErrorMessage = document.querySelector('.pwd_error_message');
+import {$email,$emailErrorMessage,$pwdErrorMessage,$pwd,pwdEyeOnOff,$pwdEye} from './sign.js';
 
-const $pwd = document.querySelector('.pwd_input');
-const $signBtn = document.querySelector('.btn-sign');
-const $pwdEye = document.querySelector('.password-eye');
-
-let emailValid = false;
-let pwdValid = false;
-
-const REGEMAIL = /^[A-Za-z0-9\-]+@[A-Za-z0-9]+\.[a-z]/;
-function emailErrorMessage(e){
-    emailValid = false;
-    if(e.target.value === ""){
-        $emailErrorMessage.textContent = "이메일을 입력해주세요."
+function emailDuplication(){
+    const existEmail = 'test@codeit.com'
+    if($email.value === existEmail){
+        $emailErrorMessage.textContent = "이미 사용 중인 이메일입니다."
         $emailErrorMessage.style.display ="block";
         $email.classList.add('border-red');
     }
-   else if(!REGEMAIL.test(e.target.value)){
-        $emailErrorMessage.textContent = "올바른 이메일 주소가 아닙니다."
-        $emailErrorMessage.style.display ="block";
-        $email.classList.add('border-red');
-   }
-   else{
-    $emailErrorMessage.style.display ="none";
-    $email.classList.remove("border-red");
-    emailValid = true;
-   }
 }
+$email.addEventListener("focusout", emailDuplication);
 
-function pwdErrorMessage(e){
-    pwdValid=false;
-    if(e.target.value === ""){
-        $pwdErrorMessage.textContent = "비밀번호를 입력해주세요."
+const REGPWD = /[0-9][a-zA-Z].{8,}/;
+function pwdValidation(){
+    if(!REGPWD.test($pwd.value)){
+        $pwdErrorMessage.textContent = "비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요."
         $pwdErrorMessage.style.display ="block";
         $pwd.classList.add('border-red');
     }
-    else{
-        $pwdErrorMessage.style.display ="none";
-        $pwd.classList.remove("border-red");
-        pwdValid = true;
-    }
 }
-$email.addEventListener("focusout",emailErrorMessage);
-$pwd.addEventListener("focusout",pwdErrorMessage);
+$pwd.addEventListener("focusout", pwdValidation);
 
-function signinValidCheck(e){
-    if(!emailValid){
-        $emailErrorMessage.textContent = "이메일을 확인해주세요."
-        $emailErrorMessage.style.display ="block";
-        e.preventDefault();
-    }
-    if(!pwdValid){
-        $pwdErrorMessage.textContent = "비밀번호를 확인해주세요."
-        $pwdErrorMessage.style.display ="block";
-        e.preventDefault();
-    }
-}
-document.querySelector('.form__sign').addEventListener('submit',signinValidCheck);
-
-let eyeOn = $pwdEye.src.includes('eye-on');
-function pwdEyeOnOff(e){
-    eyeOn = !eyeOn;
-    if(eyeOn){
-        e.target.src = "/img/eye-on.svg";
-        $pwd.type ="text";
-    }
-    else{
-        e.target.src = "/img/eye-off.svg";
-        $pwd.type ="password";
-    }
-}
-$pwdEye.addEventListener('click',pwdEyeOnOff);
+$pwdEye[1].addEventListener('click',pwdEyeOnOff);


### PR DESCRIPTION
## 요구사항
https://jieun-linkbrary.netlify.app/html/signup

### 기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] 이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- 4주차 요구사항 "이외의 로그인 시도 시 '이메일을 확인해주세요'"를 띄우도록 리팩토링, 추후 데이터베이스 생기면 다시 수정예정
- 공통 모듈 분리

## 스크린샷

<img width="630" alt="스크린샷 2023-10-07 오후 2 40 52" src="https://github.com/codeit-bootcamp-frontend/1-Weekly-Mission/assets/144668146/c0bce723-8edb-440d-a66b-4e557a2e1aee">

## 멘토에게

- pwdEyeOnOff 함수 하나로 '비밀번호' '비밀번호확인' 둘을 제어하기 위해 `e.target.previousElementSibling.type`를 사용했습니다. html에 의존적이라 안 좋은 코드일까요?
