### PR TITLE
[김다은] Week5

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "cSpell.words": [
     "codeit",
+    "Daum",
     "Linkbrary",
     "Pretendard"
   ]

--- a/js/signIn.js
+++ b/js/signIn.js
@@ -1,48 +1,22 @@
-// 이메일, 비밀번호 인풋값에 대한 검사를 하기 위한 변수(인풋 태그를 가져옴)
-const emailInputEl = document.querySelector('input.email');
-const passwordInputEl = document.querySelector('input.password');
-const signButton = document.querySelector('.button.try-sign');
 
-// 이메일, 비밀번호 인풋값 검사에 대한 결과(오류메세지)를 입력할 변수(인풋 태그 아래에 빈 요소를 가져옴)
-const emailErrorEl = document.querySelector('.email.error-msg');
-const passwordErrorEl = document.querySelector('.password.error-msg');
-
-// eye-off 컨포넌트 (클릭 시 eye-on으로 바꾸기 위함)
-const eyeComponent = document.querySelector('.eye-off')
-
-// 이메일 유효성 검사식
-const emailPattern = /^([\w\.\_\-])*[a-zA-Z0-9]+([\w\.\_\-])*([a-zA-Z0-9])+([\w\.\_\-])+@([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,8}$/; 
-  // 동사로 시작하는 변수는 함수
-  // TLD 2~8, 일부 특수문자 가능한 이메일로 수정(일부 Daum user email) 
-
-// 코드잇 로그인 계정 정보
-const accountInfo = Object.freeze({  // freeze(): 읽기 전용의 객체를 생성하기 위해.. depth마다 해줘야함
-  codeit: Object.freeze({
-    id: 'test@codeit.com',
-    password: 'codeit101'
-  })
-});
-
-const ActiveError = (messageTarget, message, borderTarget, borderColor = 'var(--red)') => {
-  messageTarget.textContent = message;
-  borderTarget.previousElementSibling.style.borderColor = borderColor;
-}
+import {emailInputEl, passwordInputEl, signButton, emailErrorEl, passwordErrorEl,
+  eyeComponents, emailPattern, accountInfo, activeError, eyeComponentOnOffChange} from '/js/utils.js';
 
 const checkEmailInput = () => {
   if (emailInputEl.value == '') {  // 만약 인풋 태그가 비어있다면
-    ActiveError(emailErrorEl, '이메일을 입력해주세요.', emailErrorEl);
+    activeError(emailErrorEl, '이메일을 입력해주세요.', emailErrorEl);
   } else if (emailPattern.test(emailInputEl.value) == false) {  // 이메일 유효성 검사
-    ActiveError(emailErrorEl, '올바른 이메일 주소가 아닙니다.', emailErrorEl);
+    activeError(emailErrorEl, '올바른 이메일 주소가 아닙니다.', emailErrorEl);
   } else {
-    ActiveError(emailErrorEl, '', emailErrorEl, 'var(--gray-three)');
+    activeError(emailErrorEl, '', emailErrorEl, 'var(--gray-three)');
   }
 }
 
 const checkPasswordInput = () => {
   if (passwordInputEl.value == '') { 
-    ActiveError(passwordErrorEl, '비밀번호를 입력해주세요.', eyeComponent);
+    activeError(passwordErrorEl, '비밀번호를 입력해주세요.', Array.from(eyeComponents)[0]);
   } else {
-    ActiveError(passwordErrorEl, '', eyeComponent, 'var(--gray-three)');
+    activeError(passwordErrorEl, '', Array.from(eyeComponents)[0], 'var(--gray-three)');
   }
 }
  
@@ -50,20 +24,8 @@ const TryLogin = () => {
   if (emailInputEl.value === accountInfo.codeit.id && passwordInputEl.value === accountInfo.codeit.password) {  // 만약 코드잇 계정으로 로그인 한다면
     location.replace('/folder.html');  // location.href()는 뒤로가기(이젠페이지로 이동)이 가능, replace는 불가능
   } else {
-    ActiveError(emailErrorEl, '이메일을 확인해주세요.', emailErrorEl);
-    ActiveError(passwordErrorEl, '비밀번호를 확인해주세요.', eyeComponent);
-  }
-}
-
-const EyeComponentOnOffChange = () => {
-  if (!eyeComponent.classList.contains('eye-on')) {
-    eyeComponent.src = 'assets/components/eye-on.svg';
-    eyeComponent.classList.add('eye-on');
-    eyeComponent.previousElementSibling.type ="text"
-  } else {
-    eyeComponent.src = 'assets/components/eye-off.svg';
-    eyeComponent.classList.remove('eye-on');
-    eyeComponent.previousElementSibling.type ="password";
+    activeError(emailErrorEl, '이메일을 확인해주세요.', emailErrorEl);
+    activeError(passwordErrorEl, '비밀번호를 확인해주세요.', Array.from(eyeComponents)[0]);
   }
 }
 
@@ -71,4 +33,4 @@ const EyeComponentOnOffChange = () => {
 emailInputEl.addEventListener('focusout', checkEmailInput);
 passwordInputEl.addEventListener('focusout', checkPasswordInput);
 signButton.addEventListener('click', TryLogin);
-eyeComponent.addEventListener('click', EyeComponentOnOffChange);
+[...eyeComponents].forEach(compo => compo.addEventListener('click', eyeComponentOnOffChange));

--- a/js/signIn.js
+++ b/js/signIn.js
@@ -11,58 +11,51 @@ const passwordErrorEl = document.querySelector('.password.error-msg');
 const eyeComponent = document.querySelector('.eye-off')
 
 // 이메일 유효성 검사식
-const checkRightEmail = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-Za-z0-9\-]+/;
+const emailPattern = /^([\w\.\_\-])*[a-zA-Z0-9]+([\w\.\_\-])*([a-zA-Z0-9])+([\w\.\_\-])+@([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,8}$/; 
+  // 동사로 시작하는 변수는 함수
+  // TLD 2~8, 일부 특수문자 가능한 이메일로 수정(일부 Daum user email) 
 
 // 코드잇 로그인 계정 정보
-let accountInfo = {
-  codeit: {
+const accountInfo = Object.freeze({  // freeze(): 읽기 전용의 객체를 생성하기 위해.. depth마다 해줘야함
+  codeit: Object.freeze({
     id: 'test@codeit.com',
     password: 'codeit101'
-  }
+  })
+});
+
+const ActiveError = (messageTarget, message, borderTarget, borderColor = 'var(--red)') => {
+  messageTarget.textContent = message;
+  borderTarget.previousElementSibling.style.borderColor = borderColor;
 }
 
-// 실행할 이벤트 핸들러
-emailInputEl.addEventListener('focusout', EmailInputCheck);
-passwordInputEl.addEventListener('focusout', PasswordInputCheck);
-LoginButton.addEventListener('click', TryLogin);
-eyeComponent.addEventListener('click', EyeComponentOnOffChange);
-
-
-function EmailInputCheck(e) {
+const checkEmailInput = () => {
   if (emailInputEl.value == '') {  // 만약 인풋 태그가 비어있다면
-    emailErrorEl.textContent = '이메일을 입력해주세요.';  // emailErrorEl에 해당 메세지 출력
-    emailErrorEl.previousElementSibling.style.borderColor = 'var(--red)';
-  } else if (checkRightEmail.test(emailInputEl.value) == false) {  // 이메일 유효성 검사
-    emailErrorEl.textContent = '올바른 이메일 주소가 아닙니다.'; 
-    emailErrorEl.previousElementSibling.style.borderColor = 'var(--red)';
+    ActiveError(emailErrorEl, '이메일을 입력해주세요.', emailErrorEl);
+  } else if (emailPattern.test(emailInputEl.value) == false) {  // 이메일 유효성 검사
+    ActiveError(emailErrorEl, '올바른 이메일 주소가 아닙니다.', emailErrorEl);
   } else {
-    emailErrorEl.textContent = ''; 
-    emailErrorEl.previousElementSibling.style.borderColor = 'var(--gray-three)';
+    ActiveError(emailErrorEl, '', emailErrorEl, 'var(--gray-three)');
   }
 }
 
-function PasswordInputCheck(e) {
+const checkPasswordInput = () => {
   if (passwordInputEl.value == '') { 
-    passwordErrorEl.textContent = '비밀번호를 입력해주세요.';
-    eyeComponent.previousElementSibling.style.borderColor = 'var(--red)';
+    ActiveError(passwordErrorEl, '비밀번호를 입력해주세요.', eyeComponent);
   } else {
-    passwordErrorEl.textContent = '';
-    eyeComponent.previousElementSibling.style.borderColor = 'var(--gray-three)';
+    ActiveError(passwordErrorEl, '', eyeComponent, 'var(--gray-three)');
   }
 }
  
-function TryLogin(e) {
+const TryLogin = () => {
   if (emailInputEl.value === accountInfo.codeit.id && passwordInputEl.value === accountInfo.codeit.password) {  // 만약 코드잇 계정으로 로그인 한다면
     location.replace('/folder.html');  // location.href()는 뒤로가기(이젠페이지로 이동)이 가능, replace는 불가능
   } else {
-    emailErrorEl.textContent = '이메일을 확인해주세요.';
-    passwordErrorEl.textContent = '비밀번호를 확인해주세요.';
-    emailErrorEl.previousElementSibling.style.borderColor = 'var(--red)';
-    eyeComponent.previousElementSibling.style.borderColor = 'var(--red)';
+    ActiveError(emailErrorEl, '이메일을 확인해주세요.', emailErrorEl);
+    ActiveError(passwordErrorEl, '비밀번호를 확인해주세요.', eyeComponent);
   }
 }
 
-function EyeComponentOnOffChange(e) {
+const EyeComponentOnOffChange = () => {
   if (!eyeComponent.classList.contains('eye-on')) {
     eyeComponent.src = 'assets/components/eye-on.svg';
     eyeComponent.classList.add('eye-on');
@@ -73,3 +66,9 @@ function EyeComponentOnOffChange(e) {
     eyeComponent.previousElementSibling.type ="password";
   }
 }
+
+// 실행할 이벤트 핸들러
+emailInputEl.addEventListener('focusout', checkEmailInput);
+passwordInputEl.addEventListener('focusout', checkPasswordInput);
+LoginButton.addEventListener('click', TryLogin);
+eyeComponent.addEventListener('click', EyeComponentOnOffChange);

--- a/js/signIn.js
+++ b/js/signIn.js
@@ -1,6 +1,12 @@
 
-import {emailInputEl, passwordInputEl, signButton, emailErrorEl, passwordErrorEl,
-  eyeComponents, emailPattern, accountInfo, activeError, eyeComponentOnOffChange} from '/js/utils.js';
+import {
+  emailInputEl, passwordInputEl, 
+  emailErrorEl, passwordErrorEl,
+  emailPattern, accountInfo, 
+  signButton, eyeComponents, 
+  activeError, eyeComponentOnOffChange
+} from '/js/utils.js';
+// Q. import * as myUtils from '/js/utils.js'; 같이 쓰는 게 더 좋을까요? 모든 변수 명마다 앞에 객체 이름이 붙는 게 더 코드가 길어질 것 같아서 그냥 가져왔는데 뭐가 더 좋을지 모르겠습니다. 찾아봤을 때는 프로젝트 크기에 따라서 유연하게 결정해도 된다고 해서요..
 
 const checkEmailInput = () => {
   if (emailInputEl.value == '') {  // 만약 인풋 태그가 비어있다면
@@ -34,3 +40,5 @@ emailInputEl.addEventListener('focusout', checkEmailInput);
 passwordInputEl.addEventListener('focusout', checkPasswordInput);
 signButton.addEventListener('click', TryLogin);
 [...eyeComponents].forEach(compo => compo.addEventListener('click', eyeComponentOnOffChange));
+emailInputEl.addEventListener('keypress', (e) => e.key === 'Enter' && TryLogin());  // e.code도 같은 결과
+passwordInputEl.addEventListener('keypress', (e) => e.key === 'Enter' && TryLogin());

--- a/js/signIn.js
+++ b/js/signIn.js
@@ -1,7 +1,7 @@
 // 이메일, 비밀번호 인풋값에 대한 검사를 하기 위한 변수(인풋 태그를 가져옴)
 const emailInputEl = document.querySelector('input.email');
 const passwordInputEl = document.querySelector('input.password');
-const LoginButton = document.querySelector('.login.button');
+const signButton = document.querySelector('.button.try-sign');
 
 // 이메일, 비밀번호 인풋값 검사에 대한 결과(오류메세지)를 입력할 변수(인풋 태그 아래에 빈 요소를 가져옴)
 const emailErrorEl = document.querySelector('.email.error-msg');
@@ -70,5 +70,5 @@ const EyeComponentOnOffChange = () => {
 // 실행할 이벤트 핸들러
 emailInputEl.addEventListener('focusout', checkEmailInput);
 passwordInputEl.addEventListener('focusout', checkPasswordInput);
-LoginButton.addEventListener('click', TryLogin);
+signButton.addEventListener('click', TryLogin);
 eyeComponent.addEventListener('click', EyeComponentOnOffChange);

--- a/js/signUp.js
+++ b/js/signUp.js
@@ -1,0 +1,93 @@
+// 이메일, 비밀번호 인풋값에 대한 검사를 하기 위한 변수(인풋 태그를 가져옴)
+const emailInputEl = document.querySelector('input.email');
+const passwordInputEl = document.querySelector('input.password');
+const passwordAgainInputEl = document.querySelector('input.password-again');
+const signButton = document.querySelector('.button.try-sign');
+
+// 이메일, 비밀번호 인풋값 검사에 대한 결과(오류메세지)를 입력할 변수(인풋 태그 아래에 빈 요소를 가져옴)
+const emailErrorEl = document.querySelector('.email.error-msg');
+const passwordErrorEl = document.querySelector('.password.error-msg');
+const passwordAgainErrorEl = document.querySelector('.password-again.error-msg');
+
+// eye-off 컨포넌트 (클릭 시 eye-on으로 바꾸기 위함)
+const eyeComponents = document.querySelectorAll('.eye-off');
+
+// 이메일 유효성 검사식
+const emailPattern = /^([\w\.\_\-])*[a-zA-Z0-9]+([\w\.\_\-])*([a-zA-Z0-9])+([\w\.\_\-])+@([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,8}$/; 
+  // 동사로 시작하는 변수는 함수
+  // TLD 2~8, 일부 특수문자 가능한 이메일로 수정(일부 Daum user email) 
+
+// 비밀번호 유효성 검사식
+const passwordPattern = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+
+// 코드잇 로그인 계정 정보
+const accountInfo = Object.freeze({  // freeze(): 읽기 전용의 객체를 생성하기 위해.. depth마다 해줘야함
+  codeit: Object.freeze({
+    id: 'test@codeit.com',
+    password: 'codeit101'
+  })
+});
+
+const ActiveError = (messageTarget, message, borderTarget, borderColor = 'var(--red)') => {
+  messageTarget.textContent = message;
+  borderTarget.previousElementSibling.style.borderColor = borderColor;
+}
+
+const checkEmailInput = () => {
+  if (emailInputEl.value == '') {  // 만약 인풋 태그가 비어있다면
+    ActiveError(emailErrorEl, '이메일을 입력해주세요.', emailErrorEl);
+  } else if (emailPattern.test(emailInputEl.value) == false) {  // 이메일 유효성 검사
+    ActiveError(emailErrorEl, '올바른 이메일 주소가 아닙니다.', emailErrorEl);
+  } else if (emailInputEl.value === accountInfo.codeit.id) {
+    ActiveError(emailErrorEl, '이미 사용중인 이메일입니다.', emailErrorEl);
+  } else {
+    ActiveError(emailErrorEl, '', emailErrorEl, 'var(--gray-three)');
+  }
+}
+
+const checkPasswordInput = () => {
+  if (!passwordPattern.test(passwordInputEl.value)) { 
+    ActiveError(passwordErrorEl, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.', Array.from(eyeComponents)[0]);
+  } else {
+    ActiveError(passwordErrorEl, '', Array.from(eyeComponents)[0], 'var(--gray-three)');
+  }
+}
+
+const checkPasswordAgainInput = () => {
+  if (passwordInputEl.value != passwordAgainInputEl.value) {
+    ActiveError(passwordAgainErrorEl, '비밀번호가 일치하지 않아요.', Array.from(eyeComponents)[1]);
+  } else {
+    ActiveError(passwordAgainErrorEl, '', Array.from(eyeComponents)[1], 'var(--gray-three)');
+  }
+}
+ 
+const TrySignUp = () => {
+  checkEmailInput();
+  checkPasswordInput();
+  checkPasswordAgainInput();
+  if (emailInputEl.value === accountInfo.codeit.id) {  // 만약 코드잇 계정으로 로그인 한다면
+    ActiveError(emailErrorEl, '이미 회원가입된 이메일입니다.', emailErrorEl);
+  } else if (!emailErrorEl.textContent  && !passwordErrorEl.textContent && !passwordAgainErrorEl.textContent) {
+    location.replace('/folder.html');
+  }
+}
+
+const EyeComponentOnOffChange = (e) => {
+  e.stopPropagation();
+  if (!e.target.classList.contains('eye-on')) {
+    e.target.src = 'assets/components/eye-on.svg';
+    e.target.classList.add('eye-on');
+    e.target.previousElementSibling.type ="text"
+  } else {
+    e.target.src = 'assets/components/eye-off.svg';
+    e.target.classList.remove('eye-on');
+    e.target.previousElementSibling.type ="password";
+  }
+}
+
+// 실행할 이벤트 핸들러
+emailInputEl.addEventListener('focusout', checkEmailInput);
+passwordInputEl.addEventListener('focusout', checkPasswordInput);
+signButton.addEventListener('click', TrySignUp);
+[...eyeComponents].forEach(compo => compo.addEventListener('click', EyeComponentOnOffChange));
+passwordAgainInputEl.addEventListener('focusout', checkPasswordAgainInput);

--- a/js/signUp.js
+++ b/js/signUp.js
@@ -1,93 +1,55 @@
-// 이메일, 비밀번호 인풋값에 대한 검사를 하기 위한 변수(인풋 태그를 가져옴)
-const emailInputEl = document.querySelector('input.email');
-const passwordInputEl = document.querySelector('input.password');
+import {emailInputEl, passwordInputEl, signButton, emailErrorEl, passwordErrorEl,
+  eyeComponents, emailPattern, accountInfo, activeError, eyeComponentOnOffChange} from '/js/utils.js';
+
+// 비밀번호 재확인 인풋값에 대한 검사를 하기 위한 변수(인풋 태그를 가져옴)
 const passwordAgainInputEl = document.querySelector('input.password-again');
-const signButton = document.querySelector('.button.try-sign');
-
-// 이메일, 비밀번호 인풋값 검사에 대한 결과(오류메세지)를 입력할 변수(인풋 태그 아래에 빈 요소를 가져옴)
-const emailErrorEl = document.querySelector('.email.error-msg');
-const passwordErrorEl = document.querySelector('.password.error-msg');
+// 검사에 대한 결과(오류메세지)를 입력할 변수(인풋 태그 아래에 빈 요소를 가져옴)
 const passwordAgainErrorEl = document.querySelector('.password-again.error-msg');
-
-// eye-off 컨포넌트 (클릭 시 eye-on으로 바꾸기 위함)
-const eyeComponents = document.querySelectorAll('.eye-off');
-
-// 이메일 유효성 검사식
-const emailPattern = /^([\w\.\_\-])*[a-zA-Z0-9]+([\w\.\_\-])*([a-zA-Z0-9])+([\w\.\_\-])+@([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,8}$/; 
-  // 동사로 시작하는 변수는 함수
-  // TLD 2~8, 일부 특수문자 가능한 이메일로 수정(일부 Daum user email) 
-
 // 비밀번호 유효성 검사식
 const passwordPattern = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
 
-// 코드잇 로그인 계정 정보
-const accountInfo = Object.freeze({  // freeze(): 읽기 전용의 객체를 생성하기 위해.. depth마다 해줘야함
-  codeit: Object.freeze({
-    id: 'test@codeit.com',
-    password: 'codeit101'
-  })
-});
-
-const ActiveError = (messageTarget, message, borderTarget, borderColor = 'var(--red)') => {
-  messageTarget.textContent = message;
-  borderTarget.previousElementSibling.style.borderColor = borderColor;
-}
-
 const checkEmailInput = () => {
   if (emailInputEl.value == '') {  // 만약 인풋 태그가 비어있다면
-    ActiveError(emailErrorEl, '이메일을 입력해주세요.', emailErrorEl);
+    activeError(emailErrorEl, '이메일을 입력해주세요.', emailErrorEl);
   } else if (emailPattern.test(emailInputEl.value) == false) {  // 이메일 유효성 검사
-    ActiveError(emailErrorEl, '올바른 이메일 주소가 아닙니다.', emailErrorEl);
+    activeError(emailErrorEl, '올바른 이메일 주소가 아닙니다.', emailErrorEl);
   } else if (emailInputEl.value === accountInfo.codeit.id) {
-    ActiveError(emailErrorEl, '이미 사용중인 이메일입니다.', emailErrorEl);
+    activeError(emailErrorEl, '이미 사용중인 이메일입니다.', emailErrorEl);
   } else {
-    ActiveError(emailErrorEl, '', emailErrorEl, 'var(--gray-three)');
+    activeError(emailErrorEl, '', emailErrorEl, 'var(--gray-three)');
   }
 }
 
 const checkPasswordInput = () => {
   if (!passwordPattern.test(passwordInputEl.value)) { 
-    ActiveError(passwordErrorEl, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.', Array.from(eyeComponents)[0]);
+    activeError(passwordErrorEl, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.', Array.from(eyeComponents)[0]);
   } else {
-    ActiveError(passwordErrorEl, '', Array.from(eyeComponents)[0], 'var(--gray-three)');
+    activeError(passwordErrorEl, '', Array.from(eyeComponents)[0], 'var(--gray-three)');
   }
 }
 
 const checkPasswordAgainInput = () => {
   if (passwordInputEl.value != passwordAgainInputEl.value) {
-    ActiveError(passwordAgainErrorEl, '비밀번호가 일치하지 않아요.', Array.from(eyeComponents)[1]);
+    activeError(passwordAgainErrorEl, '비밀번호가 일치하지 않아요.', Array.from(eyeComponents)[1]);
   } else {
-    ActiveError(passwordAgainErrorEl, '', Array.from(eyeComponents)[1], 'var(--gray-three)');
+    activeError(passwordAgainErrorEl, '', Array.from(eyeComponents)[1], 'var(--gray-three)');
   }
 }
  
-const TrySignUp = () => {
+const trySignUp = () => {
   checkEmailInput();
   checkPasswordInput();
   checkPasswordAgainInput();
   if (emailInputEl.value === accountInfo.codeit.id) {  // 만약 코드잇 계정으로 로그인 한다면
-    ActiveError(emailErrorEl, '이미 회원가입된 이메일입니다.', emailErrorEl);
+    activeError(emailErrorEl, '이미 회원가입된 이메일입니다.', emailErrorEl);
   } else if (!emailErrorEl.textContent  && !passwordErrorEl.textContent && !passwordAgainErrorEl.textContent) {
     location.replace('/folder.html');
-  }
-}
-
-const EyeComponentOnOffChange = (e) => {
-  e.stopPropagation();
-  if (!e.target.classList.contains('eye-on')) {
-    e.target.src = 'assets/components/eye-on.svg';
-    e.target.classList.add('eye-on');
-    e.target.previousElementSibling.type ="text"
-  } else {
-    e.target.src = 'assets/components/eye-off.svg';
-    e.target.classList.remove('eye-on');
-    e.target.previousElementSibling.type ="password";
   }
 }
 
 // 실행할 이벤트 핸들러
 emailInputEl.addEventListener('focusout', checkEmailInput);
 passwordInputEl.addEventListener('focusout', checkPasswordInput);
-signButton.addEventListener('click', TrySignUp);
-[...eyeComponents].forEach(compo => compo.addEventListener('click', EyeComponentOnOffChange));
+signButton.addEventListener('click', trySignUp);
+[...eyeComponents].forEach(compo => compo.addEventListener('click', eyeComponentOnOffChange));
 passwordAgainInputEl.addEventListener('focusout', checkPasswordAgainInput);

--- a/js/signUp.js
+++ b/js/signUp.js
@@ -1,5 +1,10 @@
-import {emailInputEl, passwordInputEl, signButton, emailErrorEl, passwordErrorEl,
-  eyeComponents, emailPattern, accountInfo, activeError, eyeComponentOnOffChange} from '/js/utils.js';
+import {
+  emailInputEl, passwordInputEl, 
+  emailErrorEl, passwordErrorEl,
+  emailPattern, accountInfo, 
+  signButton, eyeComponents, 
+  activeError, eyeComponentOnOffChange
+} from '/js/utils.js';
 
 // 비밀번호 재확인 인풋값에 대한 검사를 하기 위한 변수(인풋 태그를 가져옴)
 const passwordAgainInputEl = document.querySelector('input.password-again');
@@ -53,3 +58,6 @@ passwordInputEl.addEventListener('focusout', checkPasswordInput);
 signButton.addEventListener('click', trySignUp);
 [...eyeComponents].forEach(compo => compo.addEventListener('click', eyeComponentOnOffChange));
 passwordAgainInputEl.addEventListener('focusout', checkPasswordAgainInput);
+emailInputEl.addEventListener('keypress', (e) => e.key === 'Enter' && trySignUp());  // e.code도 같은 결과
+passwordInputEl.addEventListener('keypress', (e) => e.key === 'Enter' && trySignUp());
+passwordAgainInputEl.addEventListener('keypress', (e) => e.key === 'Enter' && trySignUp());

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,42 @@
+// 이메일, 비밀번호 인풋값에 대한 검사를 하기 위한 변수(인풋 태그를 가져옴)
+export const emailInputEl = document.querySelector('input.email');
+export const passwordInputEl = document.querySelector('input.password');
+export const signButton = document.querySelector('.button.try-sign');
+
+// 이메일, 비밀번호 인풋값 검사에 대한 결과(오류메세지)를 입력할 변수(인풋 태그 아래에 빈 요소를 가져옴)
+export const emailErrorEl = document.querySelector('.email.error-msg');
+export const passwordErrorEl = document.querySelector('.password.error-msg');
+
+// eye-off 컨포넌트 (클릭 시 eye-on으로 바꾸기 위함)
+export const eyeComponents = document.querySelectorAll('.eye-off');
+
+// 이메일 유효성 검사식
+export const emailPattern = /^([\w\.\_\-])*[a-zA-Z0-9]+([\w\.\_\-])*([a-zA-Z0-9])+([\w\.\_\-])+@([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,8}$/; 
+  // 동사로 시작하는 변수는 함수
+  // TLD 2~8, 일부 특수문자 가능한 이메일로 수정(일부 Daum user email) 
+
+// 코드잇 로그인 계정 정보
+export const accountInfo = Object.freeze({  // freeze(): 읽기 전용의 객체를 생성하기 위해.. depth마다 해줘야함
+  codeit: Object.freeze({
+    id: 'test@codeit.com',
+    password: 'codeit101'
+  })
+});
+
+export const activeError = (messageTarget, message, borderTarget, borderColor = 'var(--red)') => {
+  messageTarget.textContent = message;
+  borderTarget.previousElementSibling.style.borderColor = borderColor;
+}
+
+export const eyeComponentOnOffChange = (e) => {
+  e.stopPropagation();
+  if (!e.target.classList.contains('eye-on')) {
+    e.target.src = 'assets/components/eye-on.svg';
+    e.target.classList.add('eye-on');
+    e.target.previousElementSibling.type ="text"
+  } else {
+    e.target.src = 'assets/components/eye-off.svg';
+    e.target.classList.remove('eye-on');
+    e.target.previousElementSibling.type ="password";
+  }
+}

--- a/pages/sign.css
+++ b/pages/sign.css
@@ -127,8 +127,7 @@ input:focus {
   font-size: 1.4rem;
   color: var(--red);
   font-weight: 400;
-  position: relative;
-  left: 1rem;
+  height: 0rem;
 }
 
 @media (max-width: 1199px) {

--- a/signin.html
+++ b/signin.html
@@ -7,7 +7,7 @@
   <link href="pages/sign.css" rel="stylesheet">
   <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/static/pretendard.css">
   <title>Linkbrary</title>
-  <script defer src="js/signIn.js"></script>
+  <script defer type="module" src="js/signIn.js"></script>
 </head>
 <body>
   <div class="regular-login">

--- a/signin.html
+++ b/signin.html
@@ -33,7 +33,7 @@
       </div>
       <div class="password error-msg"></div>
     </section>
-    <section class="login button">
+    <section class="try-sign button">
       <p class="text">로그인</p>
     </section>
   </div>

--- a/signin.html
+++ b/signin.html
@@ -7,6 +7,7 @@
   <link href="pages/sign.css" rel="stylesheet">
   <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/static/pretendard.css">
   <title>Linkbrary</title>
+  <script defer src="js/signIn.js"></script>
 </head>
 <body>
   <div class="regular-login">
@@ -49,6 +50,5 @@
       </section>
     </div>
   </div>
-  <script src="js/signIn.js"></script>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -7,7 +7,7 @@
   <link href="pages/sign.css" rel="stylesheet">
   <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/static/pretendard.css">
   <title>Linkbrary</title>
-  <script defer src="js/signUp.js"></script>
+  <script defer type="module" src="js/signUp.js"></script>
 </head>
 <body>
   <div class="regular-login">

--- a/signup.html
+++ b/signup.html
@@ -7,6 +7,7 @@
   <link href="pages/sign.css" rel="stylesheet">
   <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/static/pretendard.css">
   <title>Linkbrary</title>
+  <script defer src="js/signUp.js"></script>
 </head>
 <body>
   <div class="regular-login">
@@ -22,22 +23,25 @@
     <section class="sign-field">
       <p class="text">이메일</p>
       <input class="email" name="email" type="email" required autocomplete="email" placeholder="이메일을 입력하세요.">
+      <div class="email error-msg"></div>
     </section>
     <section class="sign-field">
       <p class="text">비밀번호</p>
       <div class="input-container">
         <input class="password" name="password" type="password" required placeholder="비밀번호를 입력하세요.">
-        <img src="assets/components/eye-off.svg" class="eye-off">
-      </div>
-    </section>
-    <section class="sign-field">
-      <p class="text">비밀번호</p>
-      <div class="input-container">
-        <input class="password password-again" name="password-again" type="password" required placeholder="비밀번호를 다시 입력하세요.">
         <img src="assets/components/eye-off.svg" class="eye-off" alt="비밀번호 숨기기 아이콘">
       </div>
+      <div class="password error-msg"></div>
     </section>
-    <section class="button">
+    <section class="sign-field">
+      <p class="text">비밀번호 확인</p>
+      <div class="input-container">
+        <input class="password-again" name="password-again" type="password" required placeholder="비밀번호를 다시 입력하세요.">
+        <img src="assets/components/eye-off.svg" class="eye-off" alt="비밀번호 숨기기 아이콘">
+      </div>
+      <div class="password-again error-msg"></div>
+    </section>
+    <section class="button try-sign">
       <p class="text">회원가입</p>
     </section>
   </div>


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x]  이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x]  이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x]  비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x]  비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x]  회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x]  이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x]  회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x]  이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

<br> 

## 주요 변경사항
- 함수 선언 방식 함수 표현식으로 변경
- 동일 작업 내용에 대한 공통화 시도
- 이메일 정규식 변경
- 묘듈화

<br> 

## 스크린샷

![image](https://github.com/codeit-bootcamp-frontend/1-Weekly-Mission/assets/144599629/29f451cb-47a6-4bfc-82b3-3f9fd0cc1157)

<br> 

## 멘토에게

- 묘듈을 불러올 때 `import * as myUtils from '/js/utils.js';` 같이 쓰는 게 더 좋을까요? 모든 변수 명마다 점표기법 사용하는 게 더 코드가 길어질 것 같아서 그냥 하나씩 가져왔는데 뭐가 더 좋을지 모르겠습니다.
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
