### PR TITLE
[이규호] week5

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -1,8 +1,20 @@
 export {
   REG_EXP, 
+  DB_USERS,
 }
 
 const REG_EXP = {
   EMAIL: /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/,
   PASSWORD: /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/,
 }
+
+const DB_USERS = [
+  {
+    email: "test1@codeit.com",
+    password: "codeit101"
+  },
+
+  {
+
+  }
+]

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,0 +1,8 @@
+export {
+  REG_EXP, 
+}
+
+const REG_EXP = {
+  EMAIL: /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/,
+  PASSWORD: /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/,
+}

--- a/js/pages/signin.js
+++ b/js/pages/signin.js
@@ -47,10 +47,6 @@ function clearUserInputError(input){
   input.nextSibling.remove();
 }
 
-// function isValidEmail(email) {
-//   return email.length > 0 && !REG_EXP.EMAIL.test(email)
-// }
-
 // 로그인 에러 다루는 함수
 function handleEmailError() {
   const emailInput = $('#id-label');

--- a/js/pages/signin.js
+++ b/js/pages/signin.js
@@ -1,13 +1,15 @@
 import {
   $,
-  addClass,
-  createElement,
   isCorrectUser,
+  handleEmailError,
+  handlePasswordError,
 } from '../utils.js'
 
-import {
-  REG_EXP,
-} from '../constants.js'
+export { 
+  emailInput,
+  passwordInput,
+  loginButton,
+}
 
 const emailInput = $('#id-label');
 const passwordInput = $('#password-label');
@@ -15,69 +17,6 @@ const loginButton = $('.login-btn');
 const eyeImage = $('.eye-off');
 
 
-
-// 에러 메세지 생성 함수
-function displayUserInputError(input, message){
-  const element = createElement();
-
-  element.textContent = message;
-  input.style.borderColor = 'var(--red)';
-  addClass(element);
-
-  if(input.id === 'password-label') {
-    const passwordWrapper = $('.input-password-wrapper')
-    passwordWrapper.after(element)
-    passwordWrapper.style.marginBottom = '10px'
-    return;
-  }
-
-  input.after(element);
-}
-
-// 옳으면 에러 메세지 제거하는 함수
-function clearUserInputError(input){
-  input.style.borderColor = 'var(--gray-40)';
-
-  if(input.id === 'password-label') {
-    const passwordErrorMessage = input.parentElement.nextSibling;
-    passwordErrorMessage.remove();
-    return;
-  }
-  
-  input.nextSibling.remove();
-}
-
-// 로그인 에러 다루는 함수
-function handleEmailError() {
-  const emailInput = $('#id-label');
-  const {value: emailValue} = emailInput;
-  
-
-  if(!emailValue.trim()){
-    displayUserInputError(emailInput, '이메일을 입력해주세요.');
-    return;
-  }
-  
-  if(emailValue.length > 0 && !REG_EXP.EMAIL.test(emailValue)){
-    displayUserInputError(emailInput, '올바른 이메일 주소가 아닙니다.');
-    return;
-  }
-
-  clearUserInputError(emailInput);
-}
-
-// 비밀번호 오류시 에러 출력, 삭제 함수
-function handlePasswordEmptyError() {
-  const passwordInput = $('#password-label');
-  
-
-  if(!passwordInput.value.trim()){
-    displayUserInputError(passwordInput, '비밀번호를 입력해주세요.');
-    return;
-  }
-
-  clearUserInputError(passwordInput);
-}
 
 //로그인 성공했을 때
 function loginSuccess(){
@@ -107,17 +46,7 @@ function handleToggleEye(){
 }
 
 
-emailInput.addEventListener("focusout", handleEmailError);
-passwordInput.addEventListener("focusout", handlePasswordEmptyError);
+emailInput.addEventListener("focusout", handleEmailError,);
+passwordInput.addEventListener("focusout", handlePasswordError);
 loginButton.addEventListener("click", handleSignIn);
 eyeImage.addEventListener("click", handleToggleEye);
-
-export { 
-  emailInput,
-  passwordInput,
-  loginButton,
-  eyeImage,
-  displayUserInputError,
-  clearUserInputError,
-  handleToggleEye,
-}

--- a/js/pages/signin.js
+++ b/js/pages/signin.js
@@ -1,24 +1,24 @@
+import {
+  $,
+  addClass,
+  createElement,
+} from '../utils.js'
+
+import {
+  REG_EXP,
+} from '../constants.js'
+
 const emailInput = $('#id-label');
 const passwordInput = $('#password-label');
 const loginButton = $('.login-btn');
 const eyeImage = $('.eye-off');
 
-const emailErrorMassageElem = document.createElement('span');
-const passwordErrorMassageElem = document.createElement('span');
 
-const REG_EMAIL = /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/;
-
-function $(selector){
-  return document.querySelector(selector);
-}
-
-// 클래스 추가 함수
-function addClass(element, className = 'input-error-msg'){
-  element.classList.add(className);
-}
 
 // 에러 메세지 생성 함수
-function displayUserInputError(element, input, message){
+function displayUserInputError(input, message){
+  const element = createElement();
+
   element.textContent = message;
   input.style.borderColor = 'var(--red)';
   addClass(element);
@@ -34,40 +34,52 @@ function displayUserInputError(element, input, message){
 }
 
 // 옳으면 에러 메세지 제거하는 함수
-function clearUserInputError(element, input){
-  element.textContent = '';
+function clearUserInputError(input){
   input.style.borderColor = 'var(--gray-40)';
+
+  if(input.id === 'password-label') {
+    const passwordErrorMessage = input.parentElement.nextSibling;
+    passwordErrorMessage.remove();
+    return;
+  }
+  
+  input.nextSibling.remove();
 }
 
+// function isValidEmail(email) {
+//   return email.length > 0 && !REG_EXP.EMAIL.test(email)
+// }
+
 // 로그인 에러 다루는 함수
-function handleEmailError(event) {
+function handleEmailError() {
   const emailInput = $('#id-label');
+  const {value: emailValue} = emailInput;
   
 
-  if(!event.target.value){
-    displayUserInputError(emailErrorMassageElem, emailInput, '이메일을 입력해주세요.');
+  if(!emailValue.trim()){
+    displayUserInputError(emailInput, '이메일을 입력해주세요.');
     return;
   }
   
-  if(event.target.value.length > 0 && !REG_EMAIL.test(event.target.value)){
-    displayUserInputError(emailErrorMassageElem, emailInput, '올바른 이메일 주소가 아닙니다.');
+  if(emailValue.length > 0 && !REG_EXP.EMAIL.test(emailValue)){
+    displayUserInputError(emailInput, '올바른 이메일 주소가 아닙니다.');
     return;
   }
 
-  clearUserInputError(emailErrorMassageElem, emailInput);
+  clearUserInputError(emailInput);
 }
 
 // 비밀번호 오류시 에러 출력, 삭제 함수
-function handlePasswordEmptyError(event) {
+function handlePasswordEmptyError() {
   const passwordInput = $('#password-label');
   
 
-  if(!event.target.value){
-    displayUserInputError(passwordErrorMassageElem, passwordInput, '비밀번호를 입력해주세요.');
+  if(!passwordInput.value.trim()){
+    displayUserInputError(passwordInput, '비밀번호를 입력해주세요.');
     return;
   }
 
-  clearUserInputError(passwordErrorMassageElem, passwordInput);
+  clearUserInputError(passwordInput);
 }
 
 
@@ -76,11 +88,11 @@ function handleToggleEmail() {
   const emailInput = $('#id-label');
 
   if(emailInput.value !== "test@codeit.com"){
-    displayUserInputError(emailErrorMassageElem, emailInput, '이메일을 확인해주세요.');
+    displayUserInputError(emailInput, '이메일을 확인해주세요.');
     return;
   }
 
-  clearUserInputError(emailErrorMassageElem, emailInput);
+  clearUserInputError(emailInput);
 }
 
 
@@ -89,17 +101,17 @@ function handleTogglePassword() {
   const passwordInput = $('#password-label');
 
   if(passwordInput.value !== "codeit101"){
-    displayUserInputError(passwordErrorMassageElem, passwordInput, '비밀번호를 확인해주세요.');
+    displayUserInputError(passwordInput, '비밀번호를 확인해주세요.');
     return;
   }
 
-  clearUserInputError(passwordErrorMassageElem, passwordInput);
+  clearUserInputError(passwordInput);
 }
 
 //로그인 성공했을 때
 function loginSuccess(){
   alert('로그인 되었습니다.');
-  location.href = "../folder.html";
+  location.href = "../../folder.html";
 }
 
 // 로그인 성공, 실패 다루는 함수
@@ -127,7 +139,7 @@ function handleToggleEye(){
   const [inputType, eyeOnOff] = passwordType ? ["text", "eye-on"] : ["password", "eye-off"];
 
   passwordInput.setAttribute("type", inputType);
-  eyeImage.setAttribute("src", `../assets/png/${eyeOnOff}.png`);
+  eyeImage.setAttribute("src", `../../assets/png/${eyeOnOff}.png`);
 }
 
 
@@ -141,11 +153,6 @@ export {
   passwordInput,
   loginButton,
   eyeImage,
-  emailErrorMassageElem,
-  passwordErrorMassageElem,
-  REG_EMAIL,
-  $,
-  addClass,
   displayUserInputError,
   clearUserInputError,
   handleToggleEye,

--- a/js/pages/signin.js
+++ b/js/pages/signin.js
@@ -2,6 +2,7 @@ import {
   $,
   addClass,
   createElement,
+  isCorrectUser,
 } from '../utils.js'
 
 import {
@@ -82,32 +83,6 @@ function handlePasswordEmptyError() {
   clearUserInputError(passwordInput);
 }
 
-
-//존재하지 않는 이메일일 떄
-function handleToggleEmail() {
-  const emailInput = $('#id-label');
-
-  if(emailInput.value !== "test@codeit.com"){
-    displayUserInputError(emailInput, '이메일을 확인해주세요.');
-    return;
-  }
-
-  clearUserInputError(emailInput);
-}
-
-
-//존재하지 않는 비밀번호일 떄
-function handleTogglePassword() {
-  const passwordInput = $('#password-label');
-
-  if(passwordInput.value !== "codeit101"){
-    displayUserInputError(passwordInput, '비밀번호를 확인해주세요.');
-    return;
-  }
-
-  clearUserInputError(passwordInput);
-}
-
 //로그인 성공했을 때
 function loginSuccess(){
   alert('로그인 되었습니다.');
@@ -117,17 +92,10 @@ function loginSuccess(){
 // 로그인 성공, 실패 다루는 함수
 function handleSignIn(event){
   event.preventDefault();
-  
-  const emailInput = $('#id-label');
-  const passwordInput = $('#password-label');
 
-  if(emailInput.value === "test@codeit.com" && passwordInput.value === "codeit101"){
+  if(isCorrectUser()){
     return loginSuccess();
   }
-
-  handleToggleEmail();
-
-  handleTogglePassword()
 }
 
 // 눈모양 아이콘 다루는 함수

--- a/js/pages/signup.js
+++ b/js/pages/signup.js
@@ -20,7 +20,7 @@ const passwordCheckEyeOff = $('.password-check-eye-off');
 
 
 // 회원가입 아이디 에러 다루는 함수
-function handleSignUpEmailError(event) {
+function handleSignUpEmailError() {
   const emailInput = $('#id-label');
   const {value: emailValue} = emailInput;
 
@@ -44,7 +44,7 @@ function handleSignUpEmailError(event) {
 }
 
 // 회원가입 비밀번호 에러 다루는 함수
-function handleSignUpPasswordError(event) {
+function handleSignUpPasswordError() {
   const passwordInput = $('#password-label');
   const {value: passwordValue} = passwordInput;
 
@@ -63,7 +63,7 @@ function handleSignUpPasswordError(event) {
 }
 
 // 회원가입 비밀번호 체크 에러 다루는 함수
-function handleSignUpPasswordCheckError(event) {
+function handleSignUpPasswordCheckError() {
   const passwordInput = $('#password-label');
   const passwordCheckInput = $('#password-check-label');
 

--- a/js/pages/signup.js
+++ b/js/pages/signup.js
@@ -3,60 +3,67 @@ import {
   passwordInput,
   loginButton,
   eyeImage,
-  emailErrorMassageElem,
-  passwordErrorMassageElem,
-  REG_EMAIL,
-  $,
-  addClass,
   displayUserInputError,
   clearUserInputError,
   handleToggleEye,
-} from './signin.js';
+} from '../pages/signin.js';
+
+import {
+  $,
+  addClass,
+  createElement,
+  isValidUserInput,
+} from '../utils.js'
+
+import {
+  REG_EXP,
+} from '../constants.js'
 
 const passwordCheckInput = $('#password-check-label');
 const passwordCheckEyeOff = $('.password-check-eye-off');
 
-const REG_PASSWORD = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/;
 
 // 회원가입 아이디 에러 다루는 함수
 function handleSignUpEmailError(event) {
   const emailInput = $('#id-label');
+  const {value: emailValue} = emailInput;
 
-  if(!event.target.value){
-    displayUserInputError(emailErrorMassageElem, emailInput, '이메일을 입력해주세요.');
+  if(!emailValue.trim()){
+    displayUserInputError(emailInput, '이메일을 입력해주세요.');
     return;
   }
   
-  if(event.target.value.length > 0 && !REG_EMAIL.test(event.target.value)){
-    displayUserInputError(emailErrorMassageElem, emailInput, '올바른 이메일 주소가 아닙니다.');
+  if(!isValidUserInput(emailValue)){
+    displayUserInputError(emailInput, '올바른 이메일 주소가 아닙니다.');
     return;
   }
   
-  if(event.target.value === 'test@codeit.com'){
-    displayUserInputError(emailErrorMassageElem, emailInput, '이미 사용 중인 이메일입니다.');
+  if(emailValue === 'test@codeit.com'){
+    displayUserInputError(emailInput, '이미 사용 중인 이메일입니다.');
     return;
   }
   
 
-  clearUserInputError(emailInput, emailErrorMassageElem);
+  clearUserInputError(emailInput);
 }
 
 // 회원가입 비밀번호 에러 다루는 함수
 function handleSignUpPasswordError(event) {
   const passwordInput = $('#password-label');
+  const {value: passwordValue} = passwordInput;
 
 
-  if(!event.target.value){
-    displayUserInputError(passwordErrorMassageElem, passwordInput, '비밀번호를 입력해주세요.');
+  if(!passwordValue){
+    displayUserInputError(passwordInput, '비밀번호를 입력해주세요.');
     return;
   }
   
-  if(event.target.value.length > 0 && !REG_PASSWORD.test(event.target.value)){
-    displayUserInputError(passwordErrorMassageElem, passwordInput, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.');
+  if(!isValidUserInput(passwordValue)){
+    displayUserInputError(passwordInput, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.');
     return;
   }
 
-  clearUserInputError(passwordInput, passwordErrorMassageElem);
+  clearUserInputError(passwordInput);
 }
 
 // 회원가입 비밀번호 체크 에러 다루는 함수
@@ -66,16 +73,16 @@ function handleSignUpPasswordCheckError(event) {
 
 
   if(passwordInput.value !== passwordCheckInput.value){
-    displayUserInputError(passwordErrorMassageElem, passwordCheckInput, '비밀번호가 일치하지 않아요.');
+    displayUserInputError(passwordCheckInput, '비밀번호가 일치하지 않아요.');
     return;
   }
 
-  clearUserInputError(passwordCheckInput, passwordErrorMassageElem);
+  clearUserInputError(passwordCheckInput);
 }
 
 function signupSuccess() {
   alert('회원가입이 완료되었습니다.');
-  location.href = "../folder.html";
+  location.href = "../../folder.html";
 }
 
 //회원가입 성공, 실패 다루는 함수
@@ -92,7 +99,7 @@ function handleSignUp(event){
 
   handleToggleEmail();
 
-  handleTogglePassword()
+  handleTogglePassword();
 }
 
 function handlePasswordCheckToggleEye(){
@@ -103,7 +110,7 @@ function handlePasswordCheckToggleEye(){
   const [inputType, eyeOnOff] = passwordCheckType ? ["text", "eye-on"] : ["password", "eye-off"];
 
   passwordCheckInput.setAttribute("type", inputType);
-  passwordCheckEyeOff.setAttribute("src", `../assets/png/${eyeOnOff}.png`);
+  passwordCheckEyeOff.setAttribute("src", `../../assets/png/${eyeOnOff}.png`);
 }
 
 

--- a/js/pages/signup.js
+++ b/js/pages/signup.js
@@ -2,80 +2,34 @@ import {
   emailInput,
   passwordInput,
   loginButton,
-  displayUserInputError,
-  clearUserInputError,
 } from '../pages/signin.js';
 
 import {
   $,
-  isCorrectUser,
+  handleEmailError,
+  handlePasswordError,
+  displayUserInputError,
+  clearUserInputError,
 } from '../utils.js'
-
-import {
-  REG_EXP,
-} from '../constants.js'
 
 const passwordCheckInput = $('#password-check-label');
 const passwordCheckEyeOff = $('.password-check-eye-off');
 
-
-// 회원가입 아이디 에러 다루는 함수
-function handleSignUpEmailError() {
-  const emailInput = $('#id-label');
-  const {value: emailValue} = emailInput;
-
-  if(!emailValue.trim()){
-    displayUserInputError(emailInput, '이메일을 입력해주세요.');
-    return;
-  }
-  
-  if(emailValue.length > 0 && !REG_EXP.EMAIL.test(emailValue)){
-    displayUserInputError(emailInput, '올바른 이메일 주소가 아닙니다.');
-    return;
-  }
-  
-  if(emailValue === 'test@codeit.com'){
-    displayUserInputError(emailInput, '이미 사용 중인 이메일입니다.');
-    return;
-  }
-  
-
-  clearUserInputError(emailInput);
-}
-
-// 회원가입 비밀번호 에러 다루는 함수
-function handleSignUpPasswordError() {
-  const passwordInput = $('#password-label');
-  const {value: passwordValue} = passwordInput;
-
-
-  if(!passwordValue){
-    displayUserInputError(passwordInput, '비밀번호를 입력해주세요.');
-    return;
-  }
-  
-  if(passwordValue.length > 0 && !REG_EXP.PASSWORD.test(passwordValue)){
-    displayUserInputError(passwordInput, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.');
-    return;
-  }
-
-  clearUserInputError(passwordInput);
-}
 
 // 회원가입 비밀번호 체크 에러 다루는 함수
 function handleSignUpPasswordCheckError() {
   const passwordInput = $('#password-label');
   const passwordCheckInput = $('#password-check-label');
 
+  clearUserInputError(passwordCheckInput);
 
   if(passwordInput.value !== passwordCheckInput.value){
     displayUserInputError(passwordCheckInput, '비밀번호가 일치하지 않아요.');
     return;
   }
-
-  clearUserInputError(passwordCheckInput);
 }
 
+// 회원가입 성공했을 때
 function signupSuccess() {
   alert('회원가입이 완료되었습니다.');
   location.href = "../../folder.html";
@@ -94,6 +48,7 @@ function handleSignUp(event){
   }
 }
 
+// 비밀번호 체크 눈모양 아이콘 다루는 함수
 function handlePasswordCheckToggleEye(){
   const passwordCheckInput = $('#password-check-label');
   const passwordCheckEyeOff = $('.password-check-eye-off');
@@ -107,8 +62,8 @@ function handlePasswordCheckToggleEye(){
 
 
 
-emailInput.addEventListener("focusout", handleSignUpEmailError);
-passwordInput.addEventListener("focusout", handleSignUpPasswordError);
+emailInput.addEventListener("focusout", handleEmailError);
+passwordInput.addEventListener("focusout", handlePasswordError);
 passwordCheckEyeOff.addEventListener("click", handlePasswordCheckToggleEye);
 loginButton.addEventListener("click", handleSignUp);
 passwordCheckInput.addEventListener("focusout", handleSignUpPasswordCheckError);

--- a/js/pages/signup.js
+++ b/js/pages/signup.js
@@ -2,17 +2,13 @@ import {
   emailInput,
   passwordInput,
   loginButton,
-  eyeImage,
   displayUserInputError,
   clearUserInputError,
-  handleToggleEye,
 } from '../pages/signin.js';
 
 import {
   $,
-  addClass,
-  createElement,
-  isValidUserInput,
+  isCorrectUser,
 } from '../utils.js'
 
 import {
@@ -33,7 +29,7 @@ function handleSignUpEmailError(event) {
     return;
   }
   
-  if(!isValidUserInput(emailValue)){
+  if(emailValue.length > 0 && !REG_EXP.EMAIL.test(emailValue)){
     displayUserInputError(emailInput, '올바른 이메일 주소가 아닙니다.');
     return;
   }
@@ -58,7 +54,7 @@ function handleSignUpPasswordError(event) {
     return;
   }
   
-  if(!isValidUserInput(passwordValue)){
+  if(passwordValue.length > 0 && !REG_EXP.PASSWORD.test(passwordValue)){
     displayUserInputError(passwordInput, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.');
     return;
   }
@@ -96,10 +92,6 @@ function handleSignUp(event){
   if(emailInput.value !== "test@codeit.com" && passwordInput.value === passwordCheckInput.value){
     return signupSuccess();
   }
-
-  handleToggleEmail();
-
-  handleTogglePassword();
 }
 
 function handlePasswordCheckToggleEye(){

--- a/js/signin.js
+++ b/js/signin.js
@@ -4,7 +4,7 @@ const loginButton = $('.login-btn');
 const eyeImage = $('.eye-off');
 
 const emailErrorMassageElem = document.createElement('span');
-const pwErrorMassageElem = document.createElement('span');
+const passwordErrorMassageElem = document.createElement('span');
 
 const REG_EMAIL = /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/;
 
@@ -47,7 +47,9 @@ function handleEmailError(event) {
   if(!event.target.value){
     displayUserInputError(emailErrorMassageElem, emailInput, '이메일을 입력해주세요.');
     return;
-  }else if(!REG_EMAIL.test(event.target.value) && event.target.value.length > 0){
+  }
+  
+  if(event.target.value.length > 0 && !REG_EMAIL.test(event.target.value)){
     displayUserInputError(emailErrorMassageElem, emailInput, '올바른 이메일 주소가 아닙니다.');
     return;
   }
@@ -61,11 +63,11 @@ function handlePasswordEmptyError(event) {
   
 
   if(!event.target.value){
-    displayUserInputError(pwErrorMassageElem, passwordInput, '비밀번호를 입력해주세요.');
+    displayUserInputError(passwordErrorMassageElem, passwordInput, '비밀번호를 입력해주세요.');
     return;
   }
 
-  clearUserInputError(pwErrorMassageElem, passwordInput);
+  clearUserInputError(passwordErrorMassageElem, passwordInput);
 }
 
 
@@ -87,11 +89,11 @@ function handleTogglePassword() {
   const passwordInput = $('#password-label');
 
   if(passwordInput.value !== "codeit101"){
-    displayUserInputError(pwErrorMassageElem, passwordInput, '비밀번호를 확인해주세요.');
+    displayUserInputError(passwordErrorMassageElem, passwordInput, '비밀번호를 확인해주세요.');
     return;
   }
 
-  clearUserInputError(pwErrorMassageElem, passwordInput);
+  clearUserInputError(passwordErrorMassageElem, passwordInput);
 }
 
 //로그인 성공했을 때
@@ -139,6 +141,8 @@ export {
   passwordInput,
   loginButton,
   eyeImage,
+  emailErrorMassageElem,
+  passwordErrorMassageElem,
   REG_EMAIL,
   $,
   addClass,

--- a/js/signin.js
+++ b/js/signin.js
@@ -1,28 +1,36 @@
-const idInput = $('#id-label');
+const emailInput = $('#id-label');
 const passwordInput = $('#password-label');
 const loginButton = $('.login-btn');
 const eyeImage = $('.eye-off');
 
-const idErrorMassageElem = document.createElement('span');
+const emailErrorMassageElem = document.createElement('span');
 const pwErrorMassageElem = document.createElement('span');
 
-const REG_ID = /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/;
+const REG_EMAIL = /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/;
 
 function $(selector){
   return document.querySelector(selector);
 }
 
 // 클래스 추가 함수
-function addError(element, className = 'input-error-msg'){
+function addClass(element, className = 'input-error-msg'){
   element.classList.add(className);
 }
 
 // 에러 메세지 생성 함수
 function displayUserInputError(element, input, message){
-  input.after(element);
   element.textContent = message;
-  addError(element);
   input.style.borderColor = 'var(--red)';
+  addClass(element);
+
+  if(input.id === 'password-label') {
+    const passwordWrapper = $('.input-password-wrapper')
+    passwordWrapper.after(element)
+    passwordWrapper.style.marginBottom = '10px'
+    return;
+  }
+
+  input.after(element);
 }
 
 // 옳으면 에러 메세지 제거하는 함수
@@ -32,19 +40,19 @@ function clearUserInputError(element, input){
 }
 
 // 로그인 에러 다루는 함수
-function handleIdError(event) {
-  const idInput = $('#id-label');
+function handleEmailError(event) {
+  const emailInput = $('#id-label');
   
 
   if(!event.target.value){
-    displayUserInputError(idErrorMassageElem, idInput, '이메일을 입력해주세요.');
+    displayUserInputError(emailErrorMassageElem, emailInput, '이메일을 입력해주세요.');
     return;
-  }else if(!REG_ID.test(event.target.value) && event.target.value.length > 0){
-    displayUserInputError(idErrorMassageElem, idInput, '올바른 이메일 주소가 아닙니다.');
+  }else if(!REG_EMAIL.test(event.target.value) && event.target.value.length > 0){
+    displayUserInputError(emailErrorMassageElem, emailInput, '올바른 이메일 주소가 아닙니다.');
     return;
   }
 
-  clearUserInputError(idErrorMassageElem, idInput);
+  clearUserInputError(emailErrorMassageElem, emailInput);
 }
 
 // 비밀번호 오류시 에러 출력, 삭제 함수
@@ -63,14 +71,14 @@ function handlePasswordEmptyError(event) {
 
 //존재하지 않는 이메일일 떄
 function handleToggleEmail() {
-  const idInput = $('#id-label');
+  const emailInput = $('#id-label');
 
-  if(idInput.value !== "test@codeit.com"){
-    displayUserInputError(idErrorMassageElem, idInput, '이메일을 확인해주세요.');
+  if(emailInput.value !== "test@codeit.com"){
+    displayUserInputError(emailErrorMassageElem, emailInput, '이메일을 확인해주세요.');
     return;
   }
 
-  clearUserInputError(idErrorMassageElem, idInput);
+  clearUserInputError(emailErrorMassageElem, emailInput);
 }
 
 
@@ -87,18 +95,19 @@ function handleTogglePassword() {
 }
 
 //로그인 성공했을 때
-function loginSuccess(event){
-  event.preventDefault();
+function loginSuccess(){
   alert('로그인 되었습니다.');
   location.href = "../folder.html";
 }
 
 // 로그인 성공, 실패 다루는 함수
-function handleSignIn(){
-  const idInput = $('#id-label');
+function handleSignIn(event){
+  event.preventDefault();
+  
+  const emailInput = $('#id-label');
   const passwordInput = $('#password-label');
 
-  if(idInput.value === "test@codeit.com" && passwordInput.value === "codeit101"){
+  if(emailInput.value === "test@codeit.com" && passwordInput.value === "codeit101"){
     return loginSuccess();
   }
 
@@ -120,19 +129,19 @@ function handleToggleEye(){
 }
 
 
-idInput.addEventListener("focusout", handleIdError);
+emailInput.addEventListener("focusout", handleEmailError);
 passwordInput.addEventListener("focusout", handlePasswordEmptyError);
 loginButton.addEventListener("click", handleSignIn);
 eyeImage.addEventListener("click", handleToggleEye);
 
 export { 
-  idInput,
+  emailInput,
   passwordInput,
   loginButton,
   eyeImage,
-  REG_ID,
+  REG_EMAIL,
   $,
-  addError,
+  addClass,
   displayUserInputError,
   clearUserInputError,
   handleToggleEye,

--- a/js/signin.js
+++ b/js/signin.js
@@ -1,95 +1,117 @@
-const idInput = document.querySelector('#id-label');
-const pwInput = document.querySelector('#password-label');
-const idErrorMsgEl = document.createElement('span');
-const pwErrorMsgEl = document.createElement('span');
-const inputBox = document.querySelector('.input-box:nth-child(2)');
-const idInvalidMsgEl = document.createElement('span');
-const loginBtn = document.querySelector('.login-btn');
-const eyeImg = document.querySelector('.eye-off');
+const idInput = $('#id-label');
+const passwordInput = $('#password-label');
+const loginButton = $('.login-btn');
+const eyeImage = $('.eye-off');
 
 const REG_ID = /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/;
 
-function idEmpty(e) {
-  if(e.target.value.length === 0){
-    idErrorMsgEl.textContent = '이메일을 입력해주세요.';
-    idErrorMsgEl.classList.add('input-error-msg');
-    idInput.after(idErrorMsgEl);
-    idInput.style.borderColor = 'var(--red)';
-    }else{
-      idInput.style.borderColor = 'var(--gray-40)';
-      idErrorMsgEl.remove();
-    }
+function $(selector){
+  return document.querySelector(selector);
 }
 
-function idInvalid(e) {
-  if(!reg.test(e.target.value) && e.target.value.length > 0){
-    idInvalidMsgEl.textContent = '올바른 이메일 주소가 아닙니다.';
-    idInvalidMsgEl.classList.add('input-error-msg');
-    idInput.after(idInvalidMsgEl);
-    idInput.style.borderColor = 'var(--red)';
-  }else{
-    idInvalidMsgEl.remove();
+// 클래스 추가 함수
+function addError(element, className = 'input-error-msg'){
+  element.classList.add(className);
+}
+
+// 에러 메세지 생성 함수
+function displayUserInputError(element, input, message){
+  input.after(element);
+  element.textContent = message;
+  addError(element);
+  input.style.borderColor = 'var(--red)';
+}
+
+// 옳으면 에러 메세지 제거하는 함수
+function clearUserInputError(element, input){
+  element.textContent = '';
+  input.style.borderColor = 'var(--gray-40)';
+}
+
+
+function handleIdError(event) {
+  const idInput = $('#id-label');
+  const idErrorMassageElem = document.createElement('span');
+
+  if(!event.target.value){
+    displayUserInputError(idErrorMassageElem, idInput, '이메일을 입력해주세요.');
+    return;
+  }else if(!REG_ID.test(event.target.value) && event.target.value.length > 0){
+    displayUserInputError(idErrorMassageElem, idInput, '올바른 이메일 주소가 아닙니다.');
+    return;
   }
+
+  clearUserInputError(idInput, idErrorMassageElem);
 }
 
-function pwEmpty(e) {
-  if(e.target.value.length === 0){
-    pwErrorMsgEl.textContent = '비밀번호를 입력해주세요.';
-    pwErrorMsgEl.classList.add('input-error-msg');
-    inputBox.after(pwErrorMsgEl);
-    pwInput.style.borderColor = 'var(--red)';
-    }else{
-      pwInput.style.borderColor = 'var(--gray-40)';
-      pwErrorMsgEl.remove();
-    }
+function handlePasswordEmptyError(event) {
+  const passwordInput = $('#password-label');
+  const pwErrorMassageElem = document.createElement('span');
+
+  if(!event.target.value){
+    displayUserInputError(pwErrorMassageElem, passwordInput, '비밀번호를 입력해주세요.');
+    return;
+  }
+
+  clearUserInputError(passwordInput, pwErrorMassageElem);
 }
 
-function clickSigninBtn(e){
+
+
+function handleToggleEmail() {
+  const idErrorMassageElem = document.createElement('span');
+
   if(idInput.value !== "test@codeit.com"){
-    idErrorMsgEl.textContent = '이메일을 확인해주세요.';
-    idErrorMsgEl.classList.add('input-error-msg');
-    idInput.after(idErrorMsgEl);
-    idInput.style.borderColor = 'var(--red)';
-  }else{
-    idErrorMsgEl.remove();
+    displayUserInputError(idErrorMassageElem, idInput, '이메일을 입력해주세요.');
+    return;
   }
 
-  if(pwInput.value !== "codeit101"){
-    pwErrorMsgEl.textContent = '비밀번호를 확인해주세요.';
-    pwErrorMsgEl.classList.add('input-error-msg');
-    inputBox.after(pwErrorMsgEl);
-    pwInput.style.borderColor = 'var(--red)';
-    }else{
-      pwErrorMsgEl.remove();
+  clearUserInputError(idInput, idErrorMassageElem);
+}
+
+function handleTogglePassword() {
+  const pwErrorMassageElem = document.createElement('span');
+
+  if(passwordInput.value !== "codeit101"){
+    displayUserInputError(pwErrorMassageElem, passwordInput, '비밀번호를 확인해주세요.');
+    return;
   }
 
-  if(idInput.value === "test@codeit.com" && pwInput.value === "codeit101"){
-    e.preventDefault();
-    location.href = "../folder.html";
+  clearUserInputError(passwordInput, pwErrorMassageElem);
+}
+
+function loginSuccess(event){
+  event.preventDefault();
+  alert('로그인 되었습니다.');
+  location.href = "../folder.html";
+}
+
+function handleSignIn(event){
+  if(idInput.value === "test@codeit.com" && passwordInput.value === "codeit101"){
+    return loginSuccess();
   }
+
+  //존재하지 않는 이메일일 때
+  handleToggleEmail();
+
+  //존재하지 않는 비밀번호일 때
+  handleTogglePassword()
 }
 
 
+function handleToggleEye(){
+  const passwordInput = $('#password-label');
+  const eyeImage = $('.eye-off');
 
-function clickEyeImg(e){
-  const pwType = pwInput.getAttribute("type") === "password";
-  const [inputType, eyeOnOff] = pwType ? ["text", "eye-on"] : ["password", "eye-off"];
+  const passwordType = passwordInput.getAttribute("type") === "password";
+  const [inputType, eyeOnOff] = passwordType ? ["text", "eye-on"] : ["password", "eye-off"];
 
-  pwInput.setAttribute("type", inputType);
-  eyeImg.setAttribute("src", `../assets/png/${eyeOnOff}.png`)
-
-  // if(pwInput.getAttribute("type") === "password"){
-  //   pwInput.setAttribute("type", "text");
-  //   eyeImg.setAttribute("src", "../assets/png/eye-on.png");
-  // }else{
-  //   pwInput.setAttribute("type", "password");
-  //   eyeImg.setAttribute("src", "../assets/png/eye-off.png");
-  // }
+  passwordInput.setAttribute("type", inputType);
+  eyeImage.setAttribute("src", `../assets/png/${eyeOnOff}.png`);
 }
 
 
-idInput.addEventListener("focusout", idEmpty);
-idInput.addEventListener("focusout", idInvalid);
-pwInput.addEventListener("focusout", pwEmpty);
-loginBtn.addEventListener("click", clickSigninBtn);
-eyeImg.addEventListener("click", clickEyeImg);
+idInput.addEventListener("focusout", handleIdError);
+passwordInput.addEventListener("focusout", handlePasswordEmptyError);
+loginButton.addEventListener("click", handleSignIn);
+eyeImage.addEventListener("click", handleToggleEye);

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,89 +1,73 @@
 import { 
-  idInput,
+  emailInput,
   passwordInput,
   loginButton,
   eyeImage,
-  REG_ID,
+  emailErrorMassageElem,
+  passwordErrorMassageElem,
+  REG_EMAIL,
   $,
-  addError,
+  addClass,
   displayUserInputError,
   clearUserInputError,
   handleToggleEye,
 } from './signin.js';
 
-const idInput = $('#id-label');
-const passwordInput = $('#password-label');
-const loginButton = $('.login-btn');
-const eyeImage = $('.eye-off');
-const identifyInput = $('#identify-label');
+const passwordCheckInput = $('#password-check-label');
 
-const REG_ID = /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/;
 const REG_PASSWORD = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/;
 
-function $(selector){
-  return document.querySelector(selector);
-}
-
-// 클래스 추가 함수
-function addError(element, className = 'input-error-msg'){
-  element.classList.add(className);
-}
-
-// 에러 메세지 생성 함수
-function displayUserInputError(element, input, message){
-  input.after(element);
-  element.textContent = message;
-  addError(element);
-  input.style.borderColor = 'var(--red)';
-}
-
-// 옳으면 에러 메세지 제거하는 함수
-function clearUserInputError(element, input){
-  element.textContent = '';
-  input.style.borderColor = 'var(--gray-40)';
-}
-
-
-function handleSignUpIdError(event) {
-  const idInput = $('#id-label');
-  const idErrorMassageElem = document.createElement('span');
+// 회원가입 아이디 에러 다루는 함수
+function handleSignUpEmailError(event) {
+  const emailInput = $('#id-label');
 
   if(!event.target.value){
-    displayUserInputError(idErrorMassageElem, idInput, '이메일을 입력해주세요.');
+    displayUserInputError(emailErrorMassageElem, emailInput, '이메일을 입력해주세요.');
     return;
-  }else if(!REG_ID.test(event.target.value) && event.target.value.length > 0){
-    displayUserInputError(idErrorMassageElem, idInput, '올바른 이메일 주소가 아닙니다.');
+  }
+  
+  if(event.target.value.length > 0 && !REG_EMAIL.test(event.target.value)){
+    displayUserInputError(emailErrorMassageElem, emailInput, '올바른 이메일 주소가 아닙니다.');
     return;
-  }else if(idInput.value === 'test@codeit.com'){
-    displayUserInputError(idErrorMassageElem, idInput, '이미 사용 중인 이메일입니다.');
+  }
+  
+  if(event.target.value === 'test@codeit.com'){
+    displayUserInputError(emailErrorMassageElem, emailInput, '이미 사용 중인 이메일입니다.');
     return;
   }
   
 
-  clearUserInputError(idInput, idErrorMassageElem);
+  clearUserInputError(emailInput, emailErrorMassageElem);
 }
 
+// 회원가입 비밀번호 에러 다루는 함수
 function handleSignUpPasswordError(event) {
   const passwordInput = $('#password-label');
-  const pwErrorMassageElem = document.createElement('span');
+  const passwordCheckInput = $('#password-check-label');
+
 
   if(!event.target.value){
-    displayUserInputError(pwErrorMassageElem, passwordInput, '비밀번호를 입력해주세요.');
+    displayUserInputError(passwordErrorMassageElem, passwordInput, '비밀번호를 입력해주세요.');
     return;
-  }else if(!REG_PASSWORD.test(event.target.value) && event.target.value.length > 0){
-    displayUserInputError(pwErrorMassageElem, passwordInput, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.');
+  }
+  
+  if(event.target.value.length > 0 && !REG_PASSWORD.test(event.target.value)){
+    displayUserInputError(passwordErrorMassageElem, passwordInput, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.');
     return;
   }
 
-
-  clearUserInputError(passwordInput, pwErrorMassageElem);
+  clearUserInputError(passwordInput, passwordErrorMassageElem);
 }
 
+//회원가입 성공, 실패 다루는 함수
 function handleSignUp(event){
-  const idInput = $('#id-label');
-  const passwordInput = $('#password-label');
+  event.preventDefault();
 
-  if(idInput.value !== "test@codeit.com" && passwordInput.value === "codeit101"){
+  const emailInput = $('#id-label');
+  const passwordInput = $('#password-label');
+  const passwordCheckInput = $('#password-check-label');
+
+  if(emailInput.value !== "test@codeit.com" && passwordInput.value === passwordCheckInput.value){
     return loginSuccess();
   }
 
@@ -92,18 +76,20 @@ function handleSignUp(event){
   handleTogglePassword()
 }
 
-function handleToggleEye(){
-  const passwordInput = $('#password-label');
+function handlePasswordCheckToggleEye(){
+  const passwordCheckInput = $('#password-check-label');
   const eyeImage = $('.eye-off');
 
-  const passwordType = passwordInput.getAttribute("type") === "password";
+  const passwordType = passwordCheckInput.getAttribute("type") === "password";
   const [inputType, eyeOnOff] = passwordType ? ["text", "eye-on"] : ["password", "eye-off"];
 
-  passwordInput.setAttribute("type", inputType);
+  passwordCheckInput.setAttribute("type", inputType);
   eyeImage.setAttribute("src", `../assets/png/${eyeOnOff}.png`);
 }
 
-idInput.addEventListener("focusout", handleSignUpIdError);
-passwordInput.addEventListener("focusout", handleSignUpPasswordError);
-loginButton.addEventListener("click", handleSignIn);
-eyeImage.addEventListener("click", handleToggleEye);
+
+
+emailInput.addEventListener("focusout", handleSignUpEmailError);
+passwordCheckInput.addEventListener("focusout", handleSignUpPasswordError);
+eyeImage.addEventListener("click", handlePasswordCheckToggleEye);
+loginButton.addEventListener("click", handleSignUp);

--- a/js/signup.js
+++ b/js/signup.js
@@ -14,6 +14,7 @@ import {
 } from './signin.js';
 
 const passwordCheckInput = $('#password-check-label');
+const passwordCheckEyeOff = $('.password-check-eye-off');
 
 const REG_PASSWORD = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/;
 
@@ -43,7 +44,6 @@ function handleSignUpEmailError(event) {
 // 회원가입 비밀번호 에러 다루는 함수
 function handleSignUpPasswordError(event) {
   const passwordInput = $('#password-label');
-  const passwordCheckInput = $('#password-check-label');
 
 
   if(!event.target.value){
@@ -59,6 +59,25 @@ function handleSignUpPasswordError(event) {
   clearUserInputError(passwordInput, passwordErrorMassageElem);
 }
 
+// 회원가입 비밀번호 체크 에러 다루는 함수
+function handleSignUpPasswordCheckError(event) {
+  const passwordInput = $('#password-label');
+  const passwordCheckInput = $('#password-check-label');
+
+
+  if(passwordInput.value !== passwordCheckInput.value){
+    displayUserInputError(passwordErrorMassageElem, passwordCheckInput, '비밀번호가 일치하지 않아요.');
+    return;
+  }
+
+  clearUserInputError(passwordCheckInput, passwordErrorMassageElem);
+}
+
+function signupSuccess() {
+  alert('회원가입이 완료되었습니다.');
+  location.href = "../folder.html";
+}
+
 //회원가입 성공, 실패 다루는 함수
 function handleSignUp(event){
   event.preventDefault();
@@ -68,7 +87,7 @@ function handleSignUp(event){
   const passwordCheckInput = $('#password-check-label');
 
   if(emailInput.value !== "test@codeit.com" && passwordInput.value === passwordCheckInput.value){
-    return loginSuccess();
+    return signupSuccess();
   }
 
   handleToggleEmail();
@@ -78,18 +97,20 @@ function handleSignUp(event){
 
 function handlePasswordCheckToggleEye(){
   const passwordCheckInput = $('#password-check-label');
-  const eyeImage = $('.eye-off');
+  const passwordCheckEyeOff = $('.password-check-eye-off');
 
-  const passwordType = passwordCheckInput.getAttribute("type") === "password";
-  const [inputType, eyeOnOff] = passwordType ? ["text", "eye-on"] : ["password", "eye-off"];
+  const passwordCheckType = passwordCheckInput.getAttribute("type") === "password";
+  const [inputType, eyeOnOff] = passwordCheckType ? ["text", "eye-on"] : ["password", "eye-off"];
 
   passwordCheckInput.setAttribute("type", inputType);
-  eyeImage.setAttribute("src", `../assets/png/${eyeOnOff}.png`);
+  passwordCheckEyeOff.setAttribute("src", `../assets/png/${eyeOnOff}.png`);
 }
 
 
 
 emailInput.addEventListener("focusout", handleSignUpEmailError);
-passwordCheckInput.addEventListener("focusout", handleSignUpPasswordError);
-eyeImage.addEventListener("click", handlePasswordCheckToggleEye);
+passwordInput.addEventListener("focusout", handleSignUpPasswordError);
+passwordCheckEyeOff.addEventListener("click", handlePasswordCheckToggleEye);
+loginButton.addEventListener("click", handleSignUp);
+passwordCheckInput.addEventListener("focusout", handleSignUpPasswordCheckError);
 loginButton.addEventListener("click", handleSignUp);

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,12 +1,24 @@
+import { 
+  idInput,
+  passwordInput,
+  loginButton,
+  eyeImage,
+  REG_ID,
+  $,
+  addError,
+  displayUserInputError,
+  clearUserInputError,
+  handleToggleEye,
+} from './signin.js';
+
 const idInput = $('#id-label');
 const passwordInput = $('#password-label');
 const loginButton = $('.login-btn');
 const eyeImage = $('.eye-off');
-
-const idErrorMassageElem = document.createElement('span');
-const pwErrorMassageElem = document.createElement('span');
+const identifyInput = $('#identify-label');
 
 const REG_ID = /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/;
+const REG_PASSWORD = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/;
 
 function $(selector){
   return document.querySelector(selector);
@@ -31,10 +43,10 @@ function clearUserInputError(element, input){
   input.style.borderColor = 'var(--gray-40)';
 }
 
-// 로그인 에러 다루는 함수
-function handleIdError(event) {
+
+function handleSignUpIdError(event) {
   const idInput = $('#id-label');
-  
+  const idErrorMassageElem = document.createElement('span');
 
   if(!event.target.value){
     displayUserInputError(idErrorMassageElem, idInput, '이메일을 입력해주세요.');
@@ -42,63 +54,36 @@ function handleIdError(event) {
   }else if(!REG_ID.test(event.target.value) && event.target.value.length > 0){
     displayUserInputError(idErrorMassageElem, idInput, '올바른 이메일 주소가 아닙니다.');
     return;
+  }else if(idInput.value === 'test@codeit.com'){
+    displayUserInputError(idErrorMassageElem, idInput, '이미 사용 중인 이메일입니다.');
+    return;
   }
+  
 
-  clearUserInputError(idErrorMassageElem, idInput);
+  clearUserInputError(idInput, idErrorMassageElem);
 }
 
-// 비밀번호 오류시 에러 출력, 삭제 함수
-function handlePasswordEmptyError(event) {
+function handleSignUpPasswordError(event) {
   const passwordInput = $('#password-label');
-  
+  const pwErrorMassageElem = document.createElement('span');
 
   if(!event.target.value){
     displayUserInputError(pwErrorMassageElem, passwordInput, '비밀번호를 입력해주세요.');
     return;
-  }
-
-  clearUserInputError(pwErrorMassageElem, passwordInput);
-}
-
-
-//존재하지 않는 이메일일 떄
-function handleToggleEmail() {
-  const idInput = $('#id-label');
-
-  if(idInput.value !== "test@codeit.com"){
-    displayUserInputError(idErrorMassageElem, idInput, '이메일을 확인해주세요.');
+  }else if(!REG_PASSWORD.test(event.target.value) && event.target.value.length > 0){
+    displayUserInputError(pwErrorMassageElem, passwordInput, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.');
     return;
   }
 
-  clearUserInputError(idErrorMassageElem, idInput);
+
+  clearUserInputError(passwordInput, pwErrorMassageElem);
 }
 
-
-//존재하지 않는 비밀번호일 떄
-function handleTogglePassword() {
-  const passwordInput = $('#password-label');
-
-  if(passwordInput.value !== "codeit101"){
-    displayUserInputError(pwErrorMassageElem, passwordInput, '비밀번호를 확인해주세요.');
-    return;
-  }
-
-  clearUserInputError(pwErrorMassageElem, passwordInput);
-}
-
-//로그인 성공했을 때
-function loginSuccess(event){
-  event.preventDefault();
-  alert('로그인 되었습니다.');
-  location.href = "../folder.html";
-}
-
-// 로그인 성공, 실패 다루는 함수
-function handleSignIn(){
+function handleSignUp(event){
   const idInput = $('#id-label');
   const passwordInput = $('#password-label');
 
-  if(idInput.value === "test@codeit.com" && passwordInput.value === "codeit101"){
+  if(idInput.value !== "test@codeit.com" && passwordInput.value === "codeit101"){
     return loginSuccess();
   }
 
@@ -107,7 +92,6 @@ function handleSignIn(){
   handleTogglePassword()
 }
 
-// 눈모양 아이콘 다루는 함수
 function handleToggleEye(){
   const passwordInput = $('#password-label');
   const eyeImage = $('.eye-off');
@@ -119,21 +103,7 @@ function handleToggleEye(){
   eyeImage.setAttribute("src", `../assets/png/${eyeOnOff}.png`);
 }
 
-
-idInput.addEventListener("focusout", handleIdError);
-passwordInput.addEventListener("focusout", handlePasswordEmptyError);
+idInput.addEventListener("focusout", handleSignUpIdError);
+passwordInput.addEventListener("focusout", handleSignUpPasswordError);
 loginButton.addEventListener("click", handleSignIn);
 eyeImage.addEventListener("click", handleToggleEye);
-
-export { 
-  idInput,
-  passwordInput,
-  loginButton,
-  eyeImage,
-  REG_ID,
-  $,
-  addError,
-  displayUserInputError,
-  clearUserInputError,
-  handleToggleEye,
-}

--- a/js/utils.js
+++ b/js/utils.js
@@ -17,6 +17,7 @@ function isValidUserInput(email) {
   return email.length > 0 && !REG_EXP.EMAIL.test(email);
 }
 
+//이메일, 비밀번호 맞는지 확인하는 함수
 function isCorrectUser(email, password) {
   return DB_USERS.findIndex((dbUser) => {
     return dbUser.email === email && dbUser.password === password;

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,24 @@
+function $(selector){
+  return document.querySelector(selector);
+}
+
+// 클래스 추가 함수
+function addClass(element, className = 'input-error-msg'){
+  element.classList.add(className);
+}
+
+// 태그 생성 함수
+function createElement (tagName = 'span') {
+  return document.createElement(tagName);
+}
+//const createElement = () => document.createElement(tagName);
+
+function isValidUserInput(email) {
+  return email.length > 0 && !REG_EXP.EMAIL.test(email);
+}
+
+export {
+  $,
+  addClass,
+  createElement,
+}

--- a/js/utils.js
+++ b/js/utils.js
@@ -17,8 +17,15 @@ function isValidUserInput(email) {
   return email.length > 0 && !REG_EXP.EMAIL.test(email);
 }
 
+function isCorrectUser(email, password) {
+  return DB_USERS.findIndex((dbUser) => {
+    return dbUser.email === email && dbUser.password === password;
+  })
+}
+
 export {
   $,
   addClass,
   createElement,
+  isCorrectUser,
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,11 +1,29 @@
+export {
+  $,
+  addClass,
+  createElement,
+  isCorrectUser,
+  handleEmailError,
+  handlePasswordError,
+  displayUserInputError,
+  clearUserInputError,
+}
+
+import {
+  REG_EXP,
+} from './constants.js'
+
+
 function $(selector){
   return document.querySelector(selector);
 }
+
 
 // 클래스 추가 함수
 function addClass(element, className = 'input-error-msg'){
   element.classList.add(className);
 }
+
 
 // 태그 생성 함수
 function createElement (tagName = 'span') {
@@ -13,9 +31,11 @@ function createElement (tagName = 'span') {
 }
 //const createElement = () => document.createElement(tagName);
 
-function isValidUserInput(email) {
-  return email.length > 0 && !REG_EXP.EMAIL.test(email);
-}
+
+// function isValidUserInput(email) {
+//   return email.length > 0 && !REG_EXP.EMAIL.test(email);
+// }
+
 
 //이메일, 비밀번호 맞는지 확인하는 함수
 function isCorrectUser(email, password) {
@@ -24,9 +44,90 @@ function isCorrectUser(email, password) {
   })
 }
 
-export {
-  $,
-  addClass,
-  createElement,
-  isCorrectUser,
+
+// 회원가입 아이디 에러 다루는 함수
+function handleEmailError() {
+  const emailInput = $('#id-label');
+  const {value: emailValue} = emailInput;
+
+  clearUserInputError(emailInput);
+
+  if(!emailValue.trim()){
+    displayUserInputError(emailInput, '이메일을 입력해주세요.');
+    return;
+  }
+  
+  if(emailValue.length > 0 && !REG_EXP.EMAIL.test(emailValue)){
+    displayUserInputError(emailInput, '올바른 이메일 주소가 아닙니다.');
+    return;
+  }
+  
+  if(emailValue === 'test@codeit.com'){
+    displayUserInputError(emailInput, '이미 사용 중인 이메일입니다.');
+    return;
+  }
+}
+
+
+// 회원가입 비밀번호 에러 다루는 함수
+function handlePasswordError() {
+  const passwordInput = $('#password-label');
+  const {value: passwordValue} = passwordInput;
+
+  clearUserInputError(passwordInput);
+
+  if(!passwordValue.trim()){
+    displayUserInputError(passwordInput, '비밀번호를 입력해주세요.');
+    return;
+  }
+  
+  if(passwordValue.length > 0 && !REG_EXP.PASSWORD.test(passwordValue)){
+    displayUserInputError(passwordInput, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.');
+    return;
+  }
+}
+
+
+// 옳으면 에러 메세지 제거하는 함수
+function clearUserInputError(input){
+  input.style.borderColor = 'var(--gray-40)';
+  
+  if(input.id === 'password-label') {
+    const passwordErrorMessage = input.parentElement.nextSibling;
+    passwordErrorMessage.remove();
+    return;
+  }
+
+  if(input.parentElement.nextSibling.localName === 'span'){
+    input.parentElement.nextSibling.remove();
+    return;
+  }
+
+  input.nextSibling.remove();
+}
+
+
+// 에러 메세지 생성 함수
+function displayUserInputError(input, message){
+  const element = createElement();
+
+  element.textContent = message;
+  input.style.borderColor = 'var(--red)';
+  addClass(element);
+
+  if(input.id === 'password-label') {
+    const passwordWrapper = $('.input-password-wrapper')
+    passwordWrapper.after(element)
+    passwordWrapper.style.marginBottom = '10px'
+    return;
+  }
+
+  if(input.id === 'password-check-label') {
+    const passwordWrapper2 = $('.input-password-wrapper2')
+    passwordWrapper2.after(element)
+    passwordWrapper2.style.marginBottom = '10px'
+    return;
+  }
+
+  input.after(element);
 }

--- a/signin.html
+++ b/signin.html
@@ -65,6 +65,6 @@
             </footer>
           </div>
         </div>
-        <script src="./js/signin.js"></script>
+        <script type="module" src="./js/signin.js"></script>
     </body>
 </html>

--- a/signin.html
+++ b/signin.html
@@ -65,6 +65,6 @@
             </footer>
           </div>
         </div>
-        <script type="module" src="./js/signin.js"></script>
+        <script type="module" src="./js/pages/signin.js"></script>
     </body>
 </html>

--- a/signin.html
+++ b/signin.html
@@ -35,8 +35,10 @@
                         비밀번호
                     </label>
                     <div class="input-password">
-                      <input type="password" placeholder="비밀번호를 입력해주세요" id="password-label" name="passwordLabel">
+                      <div class="input-password-wrapper">
+                        <input type="password" placeholder="비밀번호를 입력해주세요" id="password-label" name="passwordLabel">
                         <img src="./assets/png/eye-off.png" alt="click to see password" class="eye-off">
+                      </div>
                     </div>
                   </div>
                   <button type="submit" class="login-btn">

--- a/signup.html
+++ b/signup.html
@@ -6,7 +6,7 @@
         <title>Linkbrary signup</title>
         <link href="./styles/reset.css" rel="stylesheet" type="text/css" />
         <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
-        <link href="./styles/signin.css" rel="stylesheet" type="text/css" />
+        <link href="./styles/signup.css" rel="stylesheet" type="text/css" />
     </head>
     <body>
         <div class="root">
@@ -46,12 +46,9 @@
                       비밀번호 확인
                   </label>
                   <div class="input-password">
-                    <div class="input-password-wrapper">
+                    <div class="input-password-wrapper2">
                       <input type="password" placeholder="비밀번호를 한번 더 입력해주세요" id="password-check-label" name="password-checkLabel">
-                      <img src="./assets/png/eye-off.png" alt="click to see password" class="password-check-eye-off" style="position: absolute;
-                      top: 50%;
-                      right: 1%;
-                      transform: translate(-50%, -50%);">
+                      <img src="./assets/png/eye-off.png" alt="click to see password" class="password-check-eye-off">
                     </div>
                   </div>
                 </div>

--- a/signup.html
+++ b/signup.html
@@ -48,7 +48,7 @@
                   <div class="input-password">
                     <div class="input-password-wrapper">
                       <input type="password" placeholder="비밀번호를 한번 더 입력해주세요" id="password-check-label" name="password-checkLabel">
-                      <img src="./assets/png/eye-off.png" alt="click to see password" class="eye-off">
+                      <img src="./assets/png/eye-off.png" alt="click to see password" class="password-check-eye-off">
                     </div>
                   </div>
                 </div>

--- a/signup.html
+++ b/signup.html
@@ -48,7 +48,10 @@
                   <div class="input-password">
                     <div class="input-password-wrapper">
                       <input type="password" placeholder="비밀번호를 한번 더 입력해주세요" id="password-check-label" name="password-checkLabel">
-                      <img src="./assets/png/eye-off.png" alt="click to see password" class="password-check-eye-off">
+                      <img src="./assets/png/eye-off.png" alt="click to see password" class="password-check-eye-off" style="position: absolute;
+                      top: 50%;
+                      right: 1%;
+                      transform: translate(-50%, -50%);">
                     </div>
                   </div>
                 </div>
@@ -76,6 +79,6 @@
             </footer>
           </div>
         </div>
-        <script type="module" src="./js/signup.js"></script>
+        <script type="module" src="./js/pages/signup.js"></script>
     </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -35,10 +35,10 @@
                       비밀번호
                   </label>
                   <div class="input-password">
-                    <input type="password" placeholder="비밀번호를 입력해주세요" id="password-label" name="passwordLabel">
-                    <button class="eye-off">
-                        <img src="./assets/png/eye-off.png" alt="click to see password">
-                    </button>
+                    <div class="input-password-wrapper">
+                      <input type="password" placeholder="비밀번호를 입력해주세요" id="password-label" name="passwordLabel">
+                      <img src="./assets/png/eye-off.png" alt="click to see password" class="eye-off">
+                    </div>
                   </div>
                 </div>
                 <div class="input-box">
@@ -46,10 +46,10 @@
                       비밀번호 확인
                   </label>
                   <div class="input-password">
-                    <input type="password" placeholder="비밀번호를 한번 더 입력해주세요" id="identify-label" name="identifyLabel">
-                    <button class="eye-off">
-                        <img src="./assets/png/eye-off.png" alt="click to see password">
-                    </button>
+                    <div class="input-password-wrapper">
+                      <input type="password" placeholder="비밀번호를 한번 더 입력해주세요" id="identify-label" name="identifyLabel">
+                      <img src="./assets/png/eye-off.png" alt="click to see password" class="eye-off">
+                    </div>
                   </div>
                 </div>
                 <button type="submit" class="login-btn">
@@ -76,5 +76,6 @@
             </footer>
           </div>
         </div>
+        <script type="module" src="./js/signup.js"></script>
     </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -42,12 +42,12 @@
                   </div>
                 </div>
                 <div class="input-box">
-                  <label for="identify-label">
+                  <label for="password-check-label">
                       비밀번호 확인
                   </label>
                   <div class="input-password">
                     <div class="input-password-wrapper">
-                      <input type="password" placeholder="비밀번호를 한번 더 입력해주세요" id="identify-label" name="identifyLabel">
+                      <input type="password" placeholder="비밀번호를 한번 더 입력해주세요" id="password-check-label" name="password-checkLabel">
                       <img src="./assets/png/eye-off.png" alt="click to see password" class="eye-off">
                     </div>
                   </div>

--- a/styles/signin.css
+++ b/styles/signin.css
@@ -94,6 +94,9 @@ input:focus {
 
 .input-password{
   width: 100%;
+}
+
+.input-password-wrapper{
   position: relative;
 }
 

--- a/styles/signup.css
+++ b/styles/signup.css
@@ -96,12 +96,13 @@ input:focus {
   top: 50%;
   right: 1%;
   transform: translate(-50%, -50%);
-  background-color: var(--color-white);
-  border: none;
 }
 
 .input-password{
   width: 100%;
+}
+
+.input-password-wrapper{
   position: relative;
 }
 

--- a/styles/signup.css
+++ b/styles/signup.css
@@ -98,6 +98,13 @@ input:focus {
   transform: translate(-50%, -50%);
 }
 
+.password-check-eye-off {
+  position: absolute;
+  top: 50%;
+  right: 1%;
+  transform: translate(-50%, -50%);
+}
+
 .input-password{
   width: 100%;
 }

--- a/styles/signup.css
+++ b/styles/signup.css
@@ -113,6 +113,10 @@ input:focus {
   position: relative;
 }
 
+.input-password-wrapper2{
+  position: relative;
+}
+
 .login-btn {
   width: 100%;
   padding: 1.6rem 2rem;


### PR DESCRIPTION
## 요구사항

### 기본

- [ ] [기본] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [ ] [기본] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [ ] [기본] 이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [ ] [기본] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [ ] [기본] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [ ] [기본] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [ ] [기본] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [ ] [기본] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [ ] [기본] 이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?


### 심화

- [ ] [심화] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [ ] [심화] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [ ] [심화] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?


## 멘토에게

- 아직 다 구현하지 못했는데 월요일까지 구현과 리팩토링 해보겠습니다. 죄송합니다.
