### PR TITLE
[김나은] Week5

### DIFF
--- a/1-Weekly-Mission/css/sign.css
+++ b/1-Weekly-Mission/css/sign.css
@@ -95,7 +95,8 @@ input:focus {
   border-color: var(--primary-color);
 }
 
-.eye_off {
+.eye_off,
+.eye_off_check {
   position: absolute;
   top: 5.2rem;
   right: 1.5rem;

--- a/1-Weekly-Mission/css/sign.css
+++ b/1-Weekly-Mission/css/sign.css
@@ -177,8 +177,7 @@ input:focus {
   border-color: var(--linkbrary-red);
 }
 
-.email_error,
-.password_error {
+.print_error_message {
   color: var(--linkbrary-red);
   font-size: 14px;
 }

--- a/1-Weekly-Mission/js/index.js
+++ b/1-Weekly-Mission/js/index.js
@@ -1,0 +1,56 @@
+// 가독성 위해 HTML tag 담는 변수 앞에 $ 붙임
+const $emailBox = document.querySelector("#email");
+const $passwordBox = document.querySelector("#password");
+const $passwordCheckBox = document.querySelector("#password_check");
+// const $submitButton = document.querySelector(".sign_button");
+const $eyeButton = document.querySelector(".eye_off");
+
+const $emailErrMsg = document.createElement("p");
+const $passwordErrMsg = document.createElement("p");
+const $passwordConfirmErrMsg = document.createElement("p");
+
+// 에러 메시지 추가
+const addError = (target, ErrorMessage) => {
+  target.classList.add("print_error_message");
+  target.textContent = ErrorMessage;
+
+  if (target === $emailErrMsg) {
+    $emailBox.after(target);
+    $emailBox.classList.add("error_border");
+  } else if (target === $passwordErrMsg) {
+    $passwordBox.after(target);
+    $passwordBox.classList.add("error_border");
+  }
+};
+
+// 에러 메시지 삭제
+const removeError = (target) => {
+  if (target === $emailErrMsg) {
+    $emailBox.classList.remove("error_border");
+  } else if (target === $passwordErrMsg) {
+    $passwordBox.classList.remove("error_border");
+  }
+  target.textContent = "";
+};
+
+// 눈모양 버튼 클릭 시 비밀번호 toggle
+const togglePassword = () => {
+  if ($passwordBox.getAttribute("type") === "password") {
+    $passwordBox.setAttribute("type", "text");
+    $eyeButton.firstElementChild.setAttribute("src", "./image/eye-on.svg");
+  } else if ($passwordBox.getAttribute("type") === "text") {
+    $passwordBox.setAttribute("type", "password");
+    $eyeButton.firstElementChild.setAttribute("src", "./image/eye-off.svg");
+  }
+};
+
+export {
+  addError,
+  removeError,
+  togglePassword,
+  $emailBox,
+  $passwordBox,
+  $eyeButton,
+  $emailErrMsg,
+  $passwordErrMsg,
+};

--- a/1-Weekly-Mission/js/index.js
+++ b/1-Weekly-Mission/js/index.js
@@ -4,6 +4,7 @@ const $passwordBox = document.querySelector("#password");
 const $passwordCheckBox = document.querySelector("#password_check");
 // const $submitButton = document.querySelector(".sign_button");
 const $eyeButton = document.querySelector(".eye_off");
+const $eyeButtonCheck = document.querySelector(".eye_off_check");
 
 const $emailErrMsg = document.createElement("p");
 const $passwordErrMsg = document.createElement("p");
@@ -18,8 +19,11 @@ const addError = (target, ErrorMessage) => {
     $emailBox.after(target);
     $emailBox.classList.add("error_border");
   } else if (target === $passwordErrMsg) {
-    $passwordBox.after(target);
+    $eyeButton.after(target);
     $passwordBox.classList.add("error_border");
+  } else if (target === $passwordConfirmErrMsg) {
+    $eyeButtonCheck.after(target);
+    $passwordCheckBox.classList.add("error_border");
   }
 };
 
@@ -29,18 +33,27 @@ const removeError = (target) => {
     $emailBox.classList.remove("error_border");
   } else if (target === $passwordErrMsg) {
     $passwordBox.classList.remove("error_border");
+  } else if (target === $passwordConfirmErrMsg) {
+    $passwordCheckBox.classList.remove("error_border");
   }
   target.textContent = "";
 };
 
 // 눈모양 버튼 클릭 시 비밀번호 toggle
-const togglePassword = () => {
-  if ($passwordBox.getAttribute("type") === "password") {
-    $passwordBox.setAttribute("type", "text");
-    $eyeButton.firstElementChild.setAttribute("src", "./image/eye-on.svg");
-  } else if ($passwordBox.getAttribute("type") === "text") {
-    $passwordBox.setAttribute("type", "password");
-    $eyeButton.firstElementChild.setAttribute("src", "./image/eye-off.svg");
+const togglePassword = (e) => {
+  e.preventDefault();
+  const $parentElement = e.target.parentElement;
+
+  if (
+    $parentElement.previousElementSibling.getAttribute("type") === "password"
+  ) {
+    $parentElement.previousElementSibling.setAttribute("type", "text");
+    e.target.setAttribute("src", "./image/eye-on.svg");
+  } else if (
+    $parentElement.previousElementSibling.getAttribute("type") === "text"
+  ) {
+    $parentElement.previousElementSibling.setAttribute("type", "password");
+    e.target.setAttribute("src", "./image/eye-off.svg");
   }
 };
 
@@ -50,7 +63,10 @@ export {
   togglePassword,
   $emailBox,
   $passwordBox,
+  $passwordCheckBox,
   $eyeButton,
+  $eyeButtonCheck,
   $emailErrMsg,
   $passwordErrMsg,
+  $passwordConfirmErrMsg,
 };

--- a/1-Weekly-Mission/js/signin.js
+++ b/1-Weekly-Mission/js/signin.js
@@ -1,76 +1,63 @@
-"use strict";
+import {
+  addError,
+  removeError,
+  togglePassword,
+  $emailBox,
+  $passwordBox,
+  $eyeButton,
+  $emailErrMsg,
+  $passwordErrMsg,
+} from "./index.js";
 
-const emailBox = document.querySelector("#email");
-const passwordBox = document.querySelector("#password");
 const submitButton = document.querySelector(".sign_button");
-const eyeButton = document.querySelector(".eye_off");
-
-// 이메일 에러메시지 생성
-const emailErrorMsg = document.createElement("p");
-emailErrorMsg.classList.add("email_error");
-emailBox.after(emailErrorMsg);
-
-// 비밀번호 에러메시지 생성
-const passwordErrorMsg = document.createElement("p");
-passwordErrorMsg.classList.add("password_error");
-passwordBox.after(passwordErrorMsg);
 
 // 이메일 정규식
-let regex = new RegExp("[a-z0-9]+@[a-z]+.[a-z]{2,3}");
+const regex = new RegExp("[a-z0-9]+@[a-z]+.[a-z]{2,3}");
 
-// 이메일 input에서 focus out할 때
-emailBox.addEventListener("blur", function (e) {
+// 이메일 입력
+const setEmailErrorMessage = (e) => {
   e.preventDefault();
 
   if (!e.target.value) {
     // 아무것도 입력하지 않았을 때
-    emailErrorMsg.textContent = "이메일을 입력해주세요.";
-    emailBox.classList.add("error_border");
+    addError($emailErrMsg, "이메일을 입력해주세요.");
   } else if (!regex.test(e.target.value) && e.target.value.length > 0) {
     // 이메일 형식에 맞지 않을 때
-    emailErrorMsg.textContent = "올바른 이메일 주소가 아닙니다.";
-    emailBox.classList.add("error_border");
+    addError($emailErrMsg, "올바른 이메일 주소가 아닙니다.");
   } else {
-    emailBox.classList.remove("error_border");
-    emailErrorMsg.textContent = "";
+    removeError($emailErrMsg);
   }
-});
+};
 
-// 비밀번호 input에서 focus out할 때
-passwordBox.addEventListener("blur", function (e) {
+// 비밀번호 입력
+const setPasswordErrorMessage = (e) => {
+  e.preventDefault();
+
   if (!e.target.value) {
     // 아무것도 입력하지 않았을 때
-    passwordErrorMsg.textContent = "비밀번호를 입력해주세요.";
-    passwordBox.classList.add("error_border");
+    addError($passwordErrMsg, "비밀번호를 입력해주세요.");
   } else {
-    passwordBox.classList.remove("error_border");
-    passwordErrorMsg.textContent = "";
+    removeError($passwordErrMsg);
   }
-});
+};
 
-// 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우
 submitButton.addEventListener("click", function (e) {
   e.preventDefault();
+  // 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우
   if (
-    emailBox.value === "test@codeit.com" &&
-    passwordBox.value === "codeit101"
+    $emailBox.value === "test@codeit.com" &&
+    $passwordBox.value === "codeit101"
   ) {
     location.href = "./folder.html";
   } else {
-    emailErrorMsg.textContent = "이메일을 확인해주세요.";
-    emailBox.classList.add("error_border");
-    passwordErrorMsg.textContent = "비밀번호를 확인해주세요.";
-    passwordBox.classList.add("error_border");
+    $emailErrorMsg.textContent = "이메일을 확인해주세요.";
+    $emailBox.classList.add("error_border");
+    $passwordErrorMsg.textContent = "비밀번호를 확인해주세요.";
+    $passwordBox.classList.add("error_border");
   }
 });
 
-// 눈모양 버튼 클릭 시 구현
-eyeButton.addEventListener("click", function (e) {
-  if (passwordBox.getAttribute("type") === "password") {
-    passwordBox.setAttribute("type", "text");
-    eyeButton.firstElementChild.setAttribute("src", "./image/eye-on.svg");
-  } else {
-    passwordBox.setAttribute("type", "password");
-    eyeButton.firstElementChild.setAttribute("src", "./image/eye-off.svg");
-  }
-});
+$emailBox.addEventListener("blur", setEmailErrorMessage);
+$passwordBox.addEventListener("blur", setPasswordErrorMessage);
+
+$eyeButton.addEventListener("click", togglePassword);

--- a/1-Weekly-Mission/js/signup.js
+++ b/1-Weekly-Mission/js/signup.js
@@ -4,15 +4,20 @@ import {
   togglePassword,
   $emailBox,
   $passwordBox,
+  $passwordCheckBox,
   $eyeButton,
+  $eyeButtonCheck,
   $emailErrMsg,
   $passwordErrMsg,
+  $passwordConfirmErrMsg,
 } from "./index.js";
 
 const $submitButton = document.querySelector(".sign_button");
 
 // 이메일 정규식
 const EMAIL_REGEX = new RegExp("[a-z0-9]+@[a-z]+.[a-z]{2,3}");
+// 비밀번호 정규식(영문, 숫자 포함 8자 이상)
+const PASSWORD_REGEX = new RegExp("^(?=.*[0-9])(?=.*[a-zA-z]).{8,}$");
 
 // 이메일 입력
 const setEmailErrorMessage = (e) => {
@@ -24,6 +29,8 @@ const setEmailErrorMessage = (e) => {
   } else if (!EMAIL_REGEX.test(e.target.value) && e.target.value.length > 0) {
     // 이메일 형식에 맞지 않을 때
     addError($emailErrMsg, "올바른 이메일 주소가 아닙니다.");
+  } else if (e.target.value === "test@codeit.com") {
+    addError($emailErrMsg, "이미 사용중인 이메일입니다.");
   } else {
     removeError($emailErrMsg);
   }
@@ -36,8 +43,25 @@ const setPasswordErrorMessage = (e) => {
   if (!e.target.value) {
     // 아무것도 입력하지 않았을 때
     addError($passwordErrMsg, "비밀번호를 입력해주세요.");
+  } else if (!PASSWORD_REGEX.test(e.target.value)) {
+    addError(
+      $passwordErrMsg,
+      "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요."
+    );
   } else {
     removeError($passwordErrMsg);
+  }
+};
+
+// 비밀번호 확인
+const setCheckPasswordErrorMessage = (e) => {
+  e.preventDefault();
+
+  if ($passwordBox.value !== $passwordCheckBox.value) {
+    // 비밀번호 input과 비밀번호 확인 input값이 다른 경우
+    addError($passwordConfirmErrMsg, "비밀번호가 일치하지 않아요.");
+  } else {
+    removeError($passwordConfirmErrMsg);
   }
 };
 
@@ -46,20 +70,25 @@ const submitForm = (e) => {
   e.preventDefault();
   // 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우
   if (
-    $emailBox.value === "test@codeit.com" &&
-    $passwordBox.value === "codeit101"
+    $emailBox.value &&
+    $passwordBox.value &&
+    $passwordCheckBox.value &&
+    !$emailErrMsg.value &&
+    !$passwordErrMsg.value &&
+    !$passwordConfirmErrMsg.value
   ) {
     location.href = "./folder.html";
   } else {
-    $emailErrorMsg.textContent = "이메일을 확인해주세요.";
-    $emailBox.classList.add("error_border");
-    $passwordErrorMsg.textContent = "비밀번호를 확인해주세요.";
-    $passwordBox.classList.add("error_border");
+    setEmailErrorMessage(e);
+    setPasswordErrorMessage(e);
+    setCheckPasswordErrorMessage(e);
   }
 };
 
 $emailBox.addEventListener("blur", setEmailErrorMessage);
 $passwordBox.addEventListener("blur", setPasswordErrorMessage);
+$passwordCheckBox.addEventListener("blur", setCheckPasswordErrorMessage);
 
 $eyeButton.addEventListener("click", togglePassword);
+$eyeButtonCheck.addEventListener("click", togglePassword);
 $submitButton.addEventListener("click", submitForm);

--- a/1-Weekly-Mission/signin.html
+++ b/1-Weekly-Mission/signin.html
@@ -53,6 +53,6 @@
         </div>
       </div>
     </main>
-    <script src="./js/signin.js"></script>
+    <script type="module" src="./js/signin.js"></script>
   </body>
 </html>

--- a/1-Weekly-Mission/signup.html
+++ b/1-Weekly-Mission/signup.html
@@ -41,7 +41,7 @@
           <div class="sign_input_box sign_password">
             <label for="password_check">비밀번호 확인</label>
             <input id="password_check" name="password" type="password" />
-            <button class="eye_off" type="button">
+            <button class="eye_off_check" type="button">
               <img src="./image/eye-off.svg" alt="눈모양 버튼 이미지" />
             </button>
           </div>
@@ -61,5 +61,6 @@
         </div>
       </div>
     </main>
+    <script type="module" src="./js/signup.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] 이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- arrow function으로 구현
- signin, singup, main js 모듈 분리

## 스크린샷

![image](이미지url)

## 멘토에게

-
-
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
