### PR TITLE
[전수빈] week5 11팀

### DIFF
--- a/css/user.css
+++ b/css/user.css
@@ -97,14 +97,16 @@ header > .userContainer {
   margin-bottom: 2.4rem;
 }
 
-.inputBoxContainer .inputContainer #pwErrorMsg {
+.inputBoxContainer .inputContainer #pwErrorMsg,
+#pwConfirmErrorMsg {
   margin-top: 0.6rem;
 }
 
-#eyeOffImg {
+.eyeOffImg {
   position: absolute;
-  top: 25%;
+  top: 2rem;
   right: 1.5rem;
+  cursor: pointer;
 }
 
 .inputBoxContainer .loginBtn {

--- a/html/login.html
+++ b/html/login.html
@@ -11,7 +11,8 @@
     />
     <link rel="stylesheet" href="/css/common.css" />
     <link rel="stylesheet" href="/css/user.css" />
-    <script defer src="../js/user.js"></script>
+    <script defer src="../js/user/user.js" type="module"></script>
+    <script defer src="../js/user/login.js" type="module"></script>
   </head>
   <body>
     <header>
@@ -45,7 +46,7 @@
               <input type="password" id="pwInput" />
               <img
                 src="/assets/user/img_eyeOff.png"
-                id="eyeOffImg"
+                class="eyeOffImg"
                 alt="eyeOffImg"
                 width="16"
                 height="16"
@@ -55,7 +56,7 @@
               </div>
             </div>
           </div>
-          <button type="button" class="loginBtn">로그인</button>
+          <button type="submit" class="loginBtn" id="loginBtn">로그인</button>
         </form>
       </section>
 

--- a/html/signup.html
+++ b/html/signup.html
@@ -11,6 +11,8 @@
     />
     <link rel="stylesheet" href="/css/common.css" />
     <link rel="stylesheet" href="/css/user.css" />
+    <script defer src="../js/user/user.js" type="module"></script>
+    <script defer src="../js/user/signup.js" type="module"></script>
   </head>
   <body>
     <header>
@@ -32,35 +34,44 @@
       <form>
         <div class="inputContainer" id="emailInputContainer">
           <label for="emailInput">이메일</label>
-          <input type="email" name="emailInput" />
+          <input type="email" id="emailInput" />
+          <div class="errorMessage" id="emailErrorMsg">
+            이메일을 입력해주세요.
+          </div>
         </div>
         <div class="inputContainer" id="pwInputContainer">
           <label for="pwInput">비밀번호</label>
           <div class="inputBox">
-            <input type="password" name="pwInput" />
+            <input type="password" id="pwInput" />
             <img
               src="/assets/user/img_eyeOff.png"
-              id="eyeOffImg"
+              class="eyeOffImg"
               alt="eyeOffImg"
               width="16"
               height="16"
             />
+            <div class="errorMessage" id="pwErrorMsg">
+              비밀번호를 입력해주세요.
+            </div>
           </div>
         </div>
         <div class="inputContainer" id="pwConfirmInputContainer">
           <label for="pwConfirmInput">비밀번호 확인</label>
           <div class="inputBox">
-            <input type="password" name="pwConfirmInput" />
+            <input type="password" id="pwConfirmInput" />
             <img
               src="/assets/user/img_eyeOff.png"
-              id="eyeOffImg"
+              class="eyeOffImg"
               alt="eyeOffImg"
               width="16"
               height="16"
             />
+            <div class="errorMessage" id="pwConfirmErrorMsg">
+              비밀번호가 일치하지 않아요.
+            </div>
           </div>
         </div>
-        <button type="submit" class="loginBtn">회원가입</button>
+        <button type="submit" class="loginBtn" id="signupBtn">회원가입</button>
       </form>
     </section>
 

--- a/js/user/login.js
+++ b/js/user/login.js
@@ -1,0 +1,22 @@
+import {
+  emailInput,
+  emailErrorMsg,
+  pwInput,
+  pwErrorMsg,
+  TEST_ID,
+  TEST_PW,
+  showError,
+} from "./user.js";
+
+const loginBtn = document.querySelector("#loginBtn");
+
+loginBtn.addEventListener("click", function (e) {
+  e.preventDefault();
+
+  if (emailInput.value === TEST_ID && pwInput.value === TEST_PW) {
+    location.href = "folder.html";
+  } else {
+    showError(pwInput, pwErrorMsg, "비밀번호를 확인해주세요");
+    showError(emailInput, emailErrorMsg, "이메일을 확인해주세요");
+  }
+});

--- a/js/user/login.js
+++ b/js/user/login.js
@@ -1,8 +1,8 @@
 import {
   emailInput,
-  emailErrorMsg,
   pwInput,
-  pwErrorMsg,
+  email,
+  password,
   TEST_ID,
   TEST_PW,
   showError,
@@ -16,7 +16,7 @@ loginBtn.addEventListener("click", function (e) {
   if (emailInput.value === TEST_ID && pwInput.value === TEST_PW) {
     location.href = "folder.html";
   } else {
-    showError(pwInput, pwErrorMsg, "비밀번호를 확인해주세요");
-    showError(emailInput, emailErrorMsg, "이메일을 확인해주세요");
+    showError(password, "비밀번호를 확인해주세요");
+    showError(email, "이메일을 확인해주세요");
   }
 });

--- a/js/user/signup.js
+++ b/js/user/signup.js
@@ -1,6 +1,7 @@
 import {
+  email,
+  password,
   emailInput,
-  emailErrorMsg,
   pwInput,
   TEST_ID,
   showError,
@@ -15,9 +16,14 @@ const pwConfirmEyeBtn = document.querySelector(
 );
 const signupBtn = document.querySelector("#signupBtn");
 
+const passwordConfirm = {
+  input: pwConfirmInput,
+  errorMsg: pwConfirmErrorMsg,
+};
+
 function validEmail() {
   if (emailInput.value === TEST_ID) {
-    showError(emailInput, emailErrorMsg, "이미 사용 중인 이메일입니다.");
+    showError(email, "이미 사용 중인 이메일입니다.");
   }
 }
 
@@ -29,13 +35,9 @@ pwInput.addEventListener("focusout", function () {
   const regexPw = /^(?=.*[a-zA-Z])(?=.*?[a-z])(?=.*?[0-9]).{8,}$/;
 
   if (!regexPw.test(pwInput.value)) {
-    showError(
-      pwInput,
-      pwErrorMsg,
-      "비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요."
-    );
+    showError(password, "비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요.");
   } else {
-    removeError(pwInput, pwErrorMsg);
+    removeError(password);
   }
 });
 
@@ -44,10 +46,10 @@ pwConfirmEyeBtn.addEventListener("click", function () {
 });
 
 pwConfirmInput.addEventListener("focusout", function () {
-  if (pwConfirmInput.value !== pwInput.value) {
-    showError(pwConfirmInput, pwConfirmErrorMsg, "비밀번호가 일치하지 않아요.");
+  if (passwordConfirm.input.value !== pwInput.value) {
+    showError(passwordConfirm, "비밀번호가 일치하지 않아요.");
   } else {
-    removeError(pwConfirmInput, pwConfirmErrorMsg);
+    removeError(passwordConfirm);
   }
 });
 

--- a/js/user/signup.js
+++ b/js/user/signup.js
@@ -1,0 +1,66 @@
+import {
+  emailInput,
+  emailErrorMsg,
+  pwInput,
+  TEST_ID,
+  showError,
+  changeEyeBtn,
+  removeError,
+} from "./user.js";
+
+const pwConfirmInput = document.querySelector("#pwConfirmInput");
+const pwConfirmErrorMsg = document.querySelector("#pwConfirmErrorMsg");
+const pwConfirmEyeBtn = document.querySelector(
+  "#pwConfirmInputContainer .eyeOffImg"
+);
+const signupBtn = document.querySelector("#signupBtn");
+
+function validEmail() {
+  if (emailInput.value === TEST_ID) {
+    showError(emailInput, emailErrorMsg, "이미 사용 중인 이메일입니다.");
+  }
+}
+
+emailInput.addEventListener("focusout", function () {
+  validEmail();
+});
+
+pwInput.addEventListener("focusout", function () {
+  const regexPw = /^(?=.*[a-zA-Z])(?=.*?[a-z])(?=.*?[0-9]).{8,}$/;
+
+  if (!regexPw.test(pwInput.value)) {
+    showError(
+      pwInput,
+      pwErrorMsg,
+      "비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요."
+    );
+  } else {
+    removeError(pwInput, pwErrorMsg);
+  }
+});
+
+pwConfirmEyeBtn.addEventListener("click", function () {
+  changeEyeBtn(pwConfirmInput, pwConfirmEyeBtn);
+});
+
+pwConfirmInput.addEventListener("focusout", function () {
+  if (pwConfirmInput.value !== pwInput.value) {
+    showError(pwConfirmInput, pwConfirmErrorMsg, "비밀번호가 일치하지 않아요.");
+  } else {
+    removeError(pwConfirmInput, pwConfirmErrorMsg);
+  }
+});
+
+signupBtn.addEventListener("click", function (e) {
+  e.preventDefault();
+  if (
+    emailInput.value &&
+    pwInput &&
+    pwConfirmInput &&
+    !emailInput.classList.contains("error") &&
+    !pwInput.classList.contains("error") &&
+    !pwConfirmInput.classList.contains("error")
+  ) {
+    location.href = "folder.html";
+  }
+});

--- a/js/user/user.js
+++ b/js/user/user.js
@@ -4,8 +4,7 @@ const emailInput = document.querySelector("#emailInput");
 const emailErrorMsg = document.querySelector("#emailErrorMsg");
 const pwInput = document.querySelector("#pwInput");
 const pwErrorMsg = document.querySelector("#pwErrorMsg");
-const loginBtn = document.querySelector(".loginBtn");
-const eyeImgBtn = document.querySelector("#eyeOffImg");
+const eyeImgBtn = document.querySelector(".eyeOffImg");
 
 function showError(input, errorMsg, msg) {
   input.classList.add("error");
@@ -13,8 +12,13 @@ function showError(input, errorMsg, msg) {
   errorMsg.style.display = "block";
 }
 
+function removeError(input, errorMsg) {
+  input.classList.remove("error");
+  errorMsg.style.display = "none";
+}
+
 function checkInput(type, input, errorMsg) {
-  var exptext = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-Za-z0-9\-]+/;
+  const exptext = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-Za-z0-9\-]+/;
 
   if (input.value === "") {
     if (type === "email") {
@@ -26,15 +30,24 @@ function checkInput(type, input, errorMsg) {
     if (type === "email" && !exptext.test(input.value)) {
       showError(input, errorMsg, "올바른 이메일 주소가 아닙니다.");
     } else {
-      input.classList.remove("error");
-      errorMsg.style.display = "none";
+      removeError(input, errorMsg);
     }
   }
 }
 
-function changePwShow(type, src) {
-  pwInput.type = type;
-  eyeImgBtn.src = src;
+function changeEyeBtn(input, btn) {
+  const eyeOnSrc = "../assets/user/img_eyeOn.png";
+  const eyeOffSrc = "../assets/user/img_eyeOff.png";
+
+  input.classList.toggle("on");
+
+  if (input.classList.contains("on")) {
+    input.type = "text";
+    btn.src = eyeOnSrc;
+  } else {
+    input.type = "password";
+    btn.src = eyeOffSrc;
+  }
 }
 
 emailInput.addEventListener("focusout", function () {
@@ -45,20 +58,18 @@ pwInput.addEventListener("focusout", function () {
   checkInput("pw", pwInput, pwErrorMsg);
 });
 
-loginBtn.addEventListener("click", function () {
-  if (emailInput.value === TEST_ID && pwInput.value === TEST_PW) {
-    location.href = "folder.html";
-  } else {
-    showError(pwInput, pwErrorMsg, "비밀번호를 확인해주세요");
-    showError(emailInput, emailErrorMsg, "이메일을 확인해주세요");
-  }
+eyeImgBtn.addEventListener("click", function () {
+  changeEyeBtn(pwInput, eyeImgBtn);
 });
 
-eyeImgBtn.addEventListener("click", function () {
-  pwInput.classList.toggle("on");
-  if (pwInput.classList[0] === "on") {
-    changePwShow("text", "../assets/user/img_eyeOn.png");
-  } else {
-    changePwShow("password", "../assets/user/img_eyeOff.png");
-  }
-});
+export {
+  emailInput,
+  emailErrorMsg,
+  pwInput,
+  pwErrorMsg,
+  TEST_ID,
+  TEST_PW,
+  showError,
+  changeEyeBtn,
+  removeError,
+};

--- a/js/user/user.js
+++ b/js/user/user.js
@@ -6,31 +6,45 @@ const pwInput = document.querySelector("#pwInput");
 const pwErrorMsg = document.querySelector("#pwErrorMsg");
 const eyeImgBtn = document.querySelector(".eyeOffImg");
 
-function showError(input, errorMsg, msg) {
+const email = {
+  input: emailInput,
+  errorMsg: emailErrorMsg,
+};
+
+const password = {
+  input: pwInput,
+  errorMsg: pwErrorMsg,
+};
+
+function showError(obj, msg) {
+  const input = obj.input;
+  const errorMsg = obj.errorMsg;
+
   input.classList.add("error");
   errorMsg.innerText = msg;
   errorMsg.style.display = "block";
 }
 
-function removeError(input, errorMsg) {
-  input.classList.remove("error");
-  errorMsg.style.display = "none";
+function removeError(obj) {
+  obj.input.classList.remove("error");
+  obj.errorMsg.style.display = "none";
 }
 
-function checkInput(type, input, errorMsg) {
+function checkInput(type, obj) {
   const exptext = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-Za-z0-9\-]+/;
+  const input = obj.input;
 
   if (input.value === "") {
     if (type === "email") {
-      showError(input, errorMsg, "이메일을 입력해주세요.");
+      showError(obj, "이메일을 입력해주세요.");
     } else {
-      showError(input, errorMsg, "비밀번호를 입력해주세요.");
+      showError(obj, "비밀번호를 입력해주세요.");
     }
   } else {
     if (type === "email" && !exptext.test(input.value)) {
-      showError(input, errorMsg, "올바른 이메일 주소가 아닙니다.");
+      showError(obj, "올바른 이메일 주소가 아닙니다.");
     } else {
-      removeError(input, errorMsg);
+      removeError(obj);
     }
   }
 }
@@ -51,22 +65,22 @@ function changeEyeBtn(input, btn) {
 }
 
 emailInput.addEventListener("focusout", function () {
-  checkInput("email", emailInput, emailErrorMsg);
+  checkInput("email", email);
 });
 
 pwInput.addEventListener("focusout", function () {
-  checkInput("pw", pwInput, pwErrorMsg);
+  checkInput("pw", password);
 });
 
 eyeImgBtn.addEventListener("click", function () {
-  changeEyeBtn(pwInput, eyeImgBtn);
+  changeEyeBtn(password.input, eyeImgBtn);
 });
 
 export {
+  email,
+  password,
   emailInput,
-  emailErrorMsg,
   pwInput,
-  pwErrorMsg,
   TEST_ID,
   TEST_PW,
   showError,


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?

- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?

- [x] 이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?

- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?

- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?

- [x] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?

- [x] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?

- [x] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?

- [x] 이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?

- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?

- [x] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- 회원가입 페이지 이메일, 비밀번호, 비밀번호 확인 유효성 검사, 에러 메세지 노출 추가
- user관련 js 파일 모듈화(공통부분 user.js에서 관리)

## 스크린샷
<img width="1660" alt="스크린샷 2023-10-08 오후 11 15 40(2)" src="https://github.com/codeit-bootcamp-frontend/1-Weekly-Mission/assets/77039033/730a2599-276e-4895-aefa-39fedfd33eff">
<img width="1665" alt="스크린샷 2023-10-08 오후 11 15 26(2)" src="https://github.com/codeit-bootcamp-frontend/1-Weekly-Mission/assets/77039033/ddd378a8-c1b1-4533-ab24-28492bb3203e">

