### PR TITLE
[김선혜] week5

### DIFF
--- a/pages/signin.html
+++ b/pages/signin.html
@@ -11,7 +11,7 @@
 	</head>
 	<body>
 		<!-- H1 (a11y) -->
-		<h1 class="page-title--a11y">Linkbrary SignIn Page</h1>
+		<h1 class="a11y">Linkbrary SignIn Page</h1>
 
 		<article id="signin__container" class="auth__container">
 			<!-- FORM -->

--- a/pages/signin.html
+++ b/pages/signin.html
@@ -8,7 +8,7 @@
 		<link rel="stylesheet" href="/styles/variables.css" />
 		<link rel="stylesheet" href="/styles/auth.css" />
 		<title>Linkbrary</title>
-		<script src="/utils/auth.js" defer></script>
+		<script type="module" src="/utils/signin.js" defer></script>
 	</head>
 	<body>
 		<!-- H1 (a11y) -->

--- a/pages/signin.html
+++ b/pages/signin.html
@@ -8,6 +8,7 @@
 		<link rel="stylesheet" href="/styles/variables.css" />
 		<link rel="stylesheet" href="/styles/auth.css" />
 		<title>Linkbrary</title>
+		<script src="/utils/auth.js" defer></script>
 	</head>
 	<body>
 		<!-- H1 (a11y) -->
@@ -105,7 +106,5 @@
 				</ul>
 			</section>
 		</article>
-
-		<script src="/utils/auth.js" defer></script>
 	</body>
 </html>

--- a/pages/signin.html
+++ b/pages/signin.html
@@ -48,6 +48,7 @@
 								<input
 									class="auth__input auth__input-password"
 									type="password"
+									autocomplete="on"
 									required
 								/>
 								<button class="auth__toggle-password" type="button">

--- a/pages/signin.html
+++ b/pages/signin.html
@@ -63,7 +63,7 @@
 							<p class="auth__password-hint"></p>
 						</label>
 					</div>
-					<button type="submit" class="auth__button signin__buton">
+					<button type="submit" class="auth__button signin__button">
 						로그인
 					</button>
 				</fieldset>

--- a/pages/signup.html
+++ b/pages/signup.html
@@ -8,6 +8,7 @@
 		<link rel="stylesheet" href="/styles/variables.css" />
 		<link rel="stylesheet" href="/styles/auth.css" />
 		<title>Linkbrary</title>
+		<script src="/utils/auth.js" defer></script>
 	</head>
 	<body>
 		<!-- H1 (a11y) -->
@@ -116,6 +117,5 @@
 				</ul>
 			</section>
 		</article>
-		<script src="/utils/auth.js" defer></script>
 	</body>
 </html>

--- a/pages/signup.html
+++ b/pages/signup.html
@@ -43,6 +43,7 @@
 								<input
 									class="auth__input auth__input-password"
 									type="password"
+									autocomplete="on"
 									required
 								/>
 								<button class="auth__toggle-password" type="button">

--- a/pages/signup.html
+++ b/pages/signup.html
@@ -8,7 +8,7 @@
 		<link rel="stylesheet" href="/styles/variables.css" />
 		<link rel="stylesheet" href="/styles/auth.css" />
 		<title>Linkbrary</title>
-		<script src="/utils/auth.js" defer></script>
+		<script type="module" src="/utils/signup.js" defer></script>
 	</head>
 	<body>
 		<!-- H1 (a11y) -->
@@ -35,7 +35,12 @@
 					<div class="auth__input-wrapper">
 						<label>
 							<p class="auth__input-title">이메일</p>
-							<input class="auth__input" type="email" required />
+							<input
+								class="auth__input auth__input-email"
+								type="email"
+								required
+							/>
+							<p class="auth__email-hint"></p>
 						</label>
 						<label>
 							<p class="auth__input-title">비밀번호</p>
@@ -56,6 +61,7 @@
 									/>
 								</button>
 							</div>
+							<p class="auth__password-hint"></p>
 						</label>
 						<label>
 							<p class="auth__input-title">비밀번호 확인</p>
@@ -63,6 +69,7 @@
 								<input
 									class="auth__input auth__input-password--confirm"
 									type="password"
+									autocomplete="on"
 									required
 								/>
 								<button class="auth__toggle-password--confirm" type="button">
@@ -75,9 +82,12 @@
 									/>
 								</button>
 							</div>
+							<p class="auth__password-hint--confirm"></p>
 						</label>
 					</div>
-					<button type="submit" class="auth__button">회원가입</button>
+					<button type="submit" class="auth__button signup__button">
+						회원가입
+					</button>
 				</fieldset>
 			</form>
 

--- a/pages/signup.html
+++ b/pages/signup.html
@@ -11,7 +11,7 @@
 	</head>
 	<body>
 		<!-- H1 (a11y) -->
-		<h1 class="page-title--a11y">Linkbrary SignUp Page</h1>
+		<h1 class="a11y">Linkbrary SignUp Page</h1>
 
 		<article id="signup__container" class="auth__container">
 			<!-- FORM -->

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -91,7 +91,7 @@ body {
 
 .auth__email-hint,
 .auth__password-hint,
-.auth__password-confirm-hint {
+.auth__password-hint--confirm {
 	min-height: 1.7rem;
 	margin-top: 0.6rem;
 	color: var(--linkbrary--color--red);

--- a/styles/global.css
+++ b/styles/global.css
@@ -8,7 +8,7 @@ html {
 	font-size: 62.5%;
 }
 
-.page-title--a11y {
+.a11y {
 	font-size: 0;
 	width: 1px;
 	height: 1px;

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -1,4 +1,5 @@
-// Signin, Signup 비밀번호 토글
+/* 비밀번호 토글 */
+// 상수
 const PASSWORD_TOGGLE_CONSTANT = {
 	visible: {
 		inputType: "text",
@@ -11,170 +12,65 @@ const PASSWORD_TOGGLE_CONSTANT = {
 		imageAlt: "비밀번호 숨김 아이콘",
 	},
 };
-const passwordToggle = document.querySelector(".auth__toggle-password");
-const passwordConfirmToggle = document.querySelector(
-	".auth__toggle-password--confirm"
-);
 
+// DOM 요소
+const passwordToggleElement = document.querySelector(".auth__toggle-password");
+
+// 함수
 function getPasswordVisibility(inputType) {
 	return inputType === "password"
 		? PASSWORD_TOGGLE_CONSTANT.visible
 		: PASSWORD_TOGGLE_CONSTANT.invisible;
 }
 
-passwordToggle.addEventListener("click", () => {
-	const passwordInput = document.querySelector(".auth__input-password");
-	const passwordIcon = document.querySelector(".auth__icon-password");
-
-	const passwordVisibility = getPasswordVisibility(passwordInput.type);
-
-	passwordInput.type = passwordVisibility.inputType;
-	passwordIcon.src = passwordVisibility.imageSrc;
-	passwordIcon.alt = passwordVisibility.imageAlt;
-});
-
-passwordConfirmToggle?.addEventListener("click", () => {
-	const passwordConfirmInput = document.querySelector(
-		".auth__input-password--confirm"
-	);
-	const passwordConfirmIcon = document.querySelector(
-		".auth__icon-password--confirm"
-	);
-
-	const passwordVisibility = getPasswordVisibility(passwordConfirmInput.type);
-
-	passwordConfirmInput.type = passwordVisibility.inputType;
-	passwordConfirmIcon.src = passwordVisibility.imageSrc;
-	passwordConfirmIcon.alt = passwordVisibility.imageAlt;
-});
-
-// Signin 유효성 검사
+/* 유효성 검사 */
+// 상수
 const USERS = [
 	{
 		email: "test@codeit.com",
 		password: "codeit101",
 	},
 ];
-const SIGNIN_HINT = {
+
+const AUTH_HINT = {
 	email: {
 		default: "",
 		isNotFilled: "이메일을 입력해주세요.",
-		isNotValidated: "올바른 이메일 주소가 아닙니다",
-		isNotUser: "이메일을 변경해주세요.",
+		isNotValidated: "올바른 이메일 주소가 아닙니다.",
+		isNotExists: "이메일을 변경해주세요.",
+		isExists: "이미 사용중인 이메일입니다.",
 	},
 	password: {
 		default: "",
 		isNotFilled: "비밀번호를 입력해주세요.",
-		isNotUser: "비밀번호를 변경해주세요.",
+		isNotExists: "비밀번호를 변경해주세요.",
+		isNotValidated: "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.",
+		isNotConfirmed: "비밀번호가 일치하지 않아요.",
 	},
 };
+
 const EMAIL_PATTERN = /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
+
 const INPUT_STATUS = {
 	default: "default",
 	isNotFilled: "isNotFilled",
 	isNotValidated: "isNotValidated",
-	isNotUser: "isNotUser",
+	isExists: "isExists",
+	isNotExists: "isNotExists",
+	isNotConfirmed: "isNotConfirmed",
 };
+
 const INPUT_HINT_CLASSNAME = "auth__input--hint";
+
 const FOLDER_PAGE_PATH = "/pages/forder.html";
 
-const emailInputElement = document.querySelector(".auth__input-email");
-const passwordInputElement = document.querySelector(".auth__input-password");
-const signinButtonElement = document.querySelector(".signin__button");
-const emailHintElement = document.querySelector(".auth__email-hint");
-const passwordHintElement = document.querySelector(".auth__password-hint");
-
-function changeEmailHint(hintType) {
-	if (emailHintElement.innerText === SIGNIN_HINT.email[hintType]) return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
-	emailHintElement.innerText = SIGNIN_HINT.email[hintType];
-
-	if (hintType === INPUT_STATUS.default) {
-		emailInputElement.classList.remove(INPUT_HINT_CLASSNAME);
-	} else {
-		emailInputElement.classList.add(INPUT_HINT_CLASSNAME);
-	}
-}
-
-function changePasswordHint(hintType) {
-	if (passwordHintElement.innerText === SIGNIN_HINT.password[hintType]) return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
-	passwordHintElement.innerText = SIGNIN_HINT.password[hintType];
-
-	if (hintType === INPUT_STATUS.default) {
-		passwordInputElement.classList.remove(INPUT_HINT_CLASSNAME);
-	} else {
-		passwordInputElement.classList.add(INPUT_HINT_CLASSNAME);
-	}
-}
-
-function signinSuccess() {
-	emailInputElement.classList.remove(INPUT_HINT_CLASSNAME);
-	passwordInputElement.classList.remove(INPUT_HINT_CLASSNAME);
-	location.href = FOLDER_PAGE_PATH;
-}
-
-function checkEmailFocusout(email) {
-	if (email === "") {
-		changeEmailHint(INPUT_STATUS.isNotFilled);
-	} else if (!EMAIL_PATTERN.test(email)) {
-		changeEmailHint(INPUT_STATUS.isNotValidated);
-	} else {
-		changeEmailHint(INPUT_STATUS.default);
-	}
-}
-
-function checkPasswordFocusout(password) {
-	if (password === "") {
-		changePasswordHint(INPUT_STATUS.isNotFilled);
-	} else {
-		changePasswordHint(INPUT_STATUS.default);
-	}
-}
-
-function getIsUserEmail(email) {
-	if (email === "") {
-		changeEmailHint(INPUT_STATUS.isNotFilled);
-		return false;
-	} else if (!EMAIL_PATTERN.test(email)) {
-		changeEmailHint(INPUT_STATUS.isNotValidated);
-		return false;
-	} else if (email !== USERS[0].email) {
-		changeEmailHint(INPUT_STATUS.isNotUser);
-		return false;
-	} else {
-		changeEmailHint(INPUT_STATUS.default);
-		return true;
-	}
-}
-
-function getIsUserPassword(password) {
-	if (password === "") {
-		changePasswordHint(INPUT_STATUS.isNotFilled);
-		return false;
-	} else if (password !== USERS[0].password) {
-		changePasswordHint(INPUT_STATUS.isNotUser);
-		return false;
-	} else {
-		changePasswordHint(INPUT_STATUS.default);
-		return true;
-	}
-}
-
-function clickSignin(email, password) {
-	const isUserEmail = getIsUserEmail(email);
-	if (!isUserEmail) return; // 유저 이메일이 아닌경우 비밀번호 검사하지 않고 리턴
-	const isUserPassword = getIsUserPassword(password);
-	if (isUserEmail && isUserPassword) signinSuccess();
-}
-
-emailInputElement.addEventListener("focusout", (e) => {
-	checkEmailFocusout(e.target.value);
-});
-
-passwordInputElement.addEventListener("focusout", (e) => {
-	checkPasswordFocusout(e.target.value);
-});
-
-signinButtonElement.addEventListener("click", (e) => {
-	e.preventDefault();
-	clickSignin(emailInputElement.value, passwordInputElement.value);
-});
+export {
+	passwordToggleElement,
+	getPasswordVisibility,
+	USERS,
+	AUTH_HINT,
+	EMAIL_PATTERN,
+	INPUT_STATUS,
+	INPUT_HINT_CLASSNAME,
+	FOLDER_PAGE_PATH,
+};

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -68,7 +68,7 @@ const SIGNIN_HINT = {
 		isNotUser: "비밀번호를 변경해주세요.",
 	},
 };
-const EMAIL_PATTURN = /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
+const EMAIL_PATTERN = /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
 
 const emailInputElement = document.querySelector(".auth__input-email");
 const passwordInputElement = document.querySelector(".auth__input-password");
@@ -106,7 +106,7 @@ function handleSigninSuccess() {
 
 function checkEmailInputValue(email) {
 	if (email === "") handleEmailHint("isNotFilled");
-	else if (EMAIL_PATTURN.test(email) === false)
+	else if (EMAIL_PATTERN.test(email) === false)
 		handleEmailHint("isNotValidated");
 	else handleEmailHint("default");
 }
@@ -125,7 +125,7 @@ function handleSignIn(email, password) {
 
 	if (email === "") {
 		handleEmailHint("isNotFilled");
-	} else if (EMAIL_PATTURN.test(email) === false) {
+	} else if (EMAIL_PATTERN.test(email) === false) {
 		handleEmailHint("isNotValidated");
 	} else if (email !== SIGNIN_CURRECT.email) {
 		handleEmailHint("isNotUser");

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -84,9 +84,7 @@ function handleEmailHint(hintType) {
 	emailHintElement.innerText = SIGNIN_HINT.email[hintType];
 	if (hintType === INPUT_STATUS.default) {
 		emailInputElement.classList.remove("auth__input--hint");
-	} else if (
-		emailInputElement.classList.contains("auth__input--hint") === false
-	) {
+	} else if (!emailInputElement.classList.contains("auth__input--hint")) {
 		emailInputElement.classList.add("auth__input--hint");
 	}
 }
@@ -95,9 +93,7 @@ function handlePasswordHint(hintType) {
 	passwordHintElement.innerText = SIGNIN_HINT.password[hintType];
 	if (hintType === "default") {
 		passwordInputElement.classList.remove("auth__input--hint");
-	} else if (
-		passwordInputElement.classList.contains("auth__input--hint") === false
-	) {
+	} else if (!passwordInputElement.classList.contains("auth__input--hint")) {
 		passwordInputElement.classList.add("auth__input--hint");
 	}
 }
@@ -111,7 +107,7 @@ function handleSigninSuccess() {
 function checkEmailInputValue(email) {
 	if (email === "") {
 		handleEmailHint(INPUT_STATUS.isNotFilled);
-	} else if (EMAIL_PATTERN.test(email) === false) {
+	} else if (!EMAIL_PATTERN.test(email)) {
 		handleEmailHint(INPUT_STATUS.isNotValidated);
 	} else {
 		handleEmailHint(INPUT_STATUS.default);
@@ -132,7 +128,7 @@ function handleSignIn(email, password) {
 
 	if (email === "") {
 		handleEmailHint(INPUT_STATUS.isNotFilled);
-	} else if (EMAIL_PATTERN.test(email) === false) {
+	} else if (!EMAIL_PATTERN.test(email)) {
 		handleEmailHint(INPUT_STATUS.isNotValidated);
 	} else if (email !== SIGNIN_CURRECT.email) {
 		handleEmailHint(INPUT_STATUS.isNotUser);

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -103,10 +103,13 @@ function handleSigninSuccess() {
 }
 
 function checkEmailInputValue(email) {
-	if (email === "") handleEmailHint("isNotFilled");
-	else if (EMAIL_PATTERN.test(email) === false)
+	if (email === "") {
+		handleEmailHint("isNotFilled");
+	} else if (EMAIL_PATTERN.test(email) === false) {
 		handleEmailHint("isNotValidated");
-	else handleEmailHint("default");
+	} else {
+		handleEmailHint("default");
+	}
 }
 
 function checkPasswordInputValue(password) {

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -73,7 +73,7 @@ const INPUT_STATUS = {
 	default: "default",
 	isNotFilled: "isNotFilled",
 	isNotValidated: "isNotValidated",
-	iaNotUser: "isNotUser",
+	isNotUser: "isNotUser",
 };
 const INPUT_HINT_CLASSNAME = "auth__input--hint";
 const FOLDER_PAGE_PATH = "/pages/forder.html";

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -16,19 +16,21 @@ const passwordConfirmToggle = document.querySelector(
 	".auth__toggle-password--confirm"
 );
 
+function getPasswordVisibility(inputType) {
+	return inputType === "password"
+		? PASSWORD_TOGGLE_CONSTANT.visible
+		: PASSWORD_TOGGLE_CONSTANT.invisible;
+}
+
 passwordToggle.addEventListener("click", () => {
 	const passwordInput = document.querySelector(".auth__input-password");
 	const passwordIcon = document.querySelector(".auth__icon-password");
 
-	if (passwordInput.type === "password") {
-		passwordInput.type = PASSWORD_TOGGLE_CONSTANT.visible.inputType;
-		passwordIcon.src = PASSWORD_TOGGLE_CONSTANT.visible.imageSrc;
-		passwordIcon.alt = PASSWORD_TOGGLE_CONSTANT.visible.imageAlt;
-	} else {
-		passwordInput.type = PASSWORD_TOGGLE_CONSTANT.invisible.inputType;
-		passwordIcon.src = PASSWORD_TOGGLE_CONSTANT.invisible.imageSrc;
-		passwordIcon.alt = PASSWORD_TOGGLE_CONSTANT.invisible.imageAlt;
-	}
+	const passwordVisibility = getPasswordVisibility(passwordInput.type);
+
+	passwordInput.type = passwordVisibility.inputType;
+	passwordIcon.src = passwordVisibility.imageSrc;
+	passwordIcon.alt = passwordVisibility.imageAlt;
 });
 
 passwordConfirmToggle?.addEventListener("click", () => {
@@ -39,15 +41,11 @@ passwordConfirmToggle?.addEventListener("click", () => {
 		".auth__icon-password--confirm"
 	);
 
-	if (passwordConfirmInput.type === "password") {
-		passwordInput.type = PASSWORD_TOGGLE_CONSTANT.visible.inputType;
-		passwordIcon.src = PASSWORD_TOGGLE_CONSTANT.invisible.imageSrc;
-		passwordIcon.alt = PASSWORD_TOGGLE_CONSTANT.invisible.imageAlt;
-	} else {
-		passwordInput.type = PASSWORD_TOGGLE_CONSTANT.invisible.inputType;
-		passwordIcon.src = PASSWORD_TOGGLE_CONSTANT.visible.imageSrc;
-		passwordIcon.alt = PASSWORD_TOGGLE_CONSTANT.visible.imageAlt;
-	}
+	const passwordVisibility = getPasswordVisibility(passwordConfirmInput.type);
+
+	passwordConfirmInput.type = passwordVisibility.inputType;
+	passwordConfirmIcon.src = passwordVisibility.imageSrc;
+	passwordConfirmIcon.alt = passwordVisibility.imageAlt;
 });
 
 // Signin 유효성 검사

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -132,32 +132,42 @@ function handlePasswordFocusoutCheck(password) {
 	}
 }
 
-function handleSignIn(email, password) {
-	let isEmailRight = false;
-	let isPasswordRight = false;
-
+function getIsUserEmail(email) {
 	if (email === "") {
 		handleEmailHint(INPUT_STATUS.isNotFilled);
+		return false;
 	} else if (!EMAIL_PATTERN.test(email)) {
 		handleEmailHint(INPUT_STATUS.isNotValidated);
+		return false;
 	} else if (email !== USERS[0].email) {
 		handleEmailHint(INPUT_STATUS.isNotUser);
+		return false;
 	} else {
-		isEmailRight = true;
+		handleEmailHint(INPUT_STATUS.default);
+		return true;
 	}
-
-	if (password === "") {
-		handlePasswordHint(INPUT_STATUS.isNotFilled);
-	} else if (password !== USERS[0].password) {
-		handlePasswordHint(INPUT_STATUS.isNotUser);
-	} else {
-		isPasswordRight = true;
-	}
-
-	if (isEmailRight === true && isPasswordRight === true) handleSigninSuccess();
 }
 
-emailInputElement.addEventListener("focusout", () => {
+function getIsUserPassword(password) {
+	if (password === "") {
+		handlePasswordHint(INPUT_STATUS.isNotFilled);
+		return false;
+	} else if (password !== USERS[0].password) {
+		handlePasswordHint(INPUT_STATUS.isNotUser);
+		return false;
+	} else {
+		handlePasswordHint(INPUT_STATUS.default);
+		return true;
+	}
+}
+
+function handleSignIn(email, password) {
+	const isUserEmail = getIsUserEmail(email);
+	const isUserPassword = getIsUserPassword(password);
+	if (isUserEmail && isUserPassword) handleSigninSuccess();
+}
+
+emailInputElement.addEventListener("focusout", (e) => {
 	const emailValue = emailInputElement.value;
 	handleEmailFocusoutCheck(emailValue);
 });

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -83,6 +83,9 @@ const emailHintElement = document.querySelector(".auth__email-hint");
 const passwordHintElement = document.querySelector(".auth__password-hint");
 
 function handleEmailHint(hintType) {
+	const hintText = emailHintElement.innerText;
+	if (hintText === SIGNIN_HINT.email[hintType]) return;
+
 	emailHintElement.innerText = SIGNIN_HINT.email[hintType];
 	if (hintType === INPUT_STATUS.default) {
 		emailInputElement.classList.remove(INPUT_HINT_CLASSNAME);
@@ -92,6 +95,9 @@ function handleEmailHint(hintType) {
 }
 
 function handlePasswordHint(hintType) {
+	const hintText = passwordHintElement.innerText;
+	if (hintText === SIGNIN_HINT.password[hintType]) return;
+
 	passwordHintElement.innerText = SIGNIN_HINT.password[hintType];
 	if (hintType === INPUT_STATUS.default) {
 		passwordInputElement.classList.remove(INPUT_HINT_CLASSNAME);

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -106,7 +106,7 @@ function handleSigninSuccess() {
 	location.href = FOLDER_PAGE_PATH;
 }
 
-function checkEmailInputValue(email) {
+function handleEmailFocusoutCheck(email) {
 	if (email === "") {
 		handleEmailHint(INPUT_STATUS.isNotFilled);
 	} else if (!EMAIL_PATTERN.test(email)) {
@@ -116,7 +116,7 @@ function checkEmailInputValue(email) {
 	}
 }
 
-function checkPasswordInputValue(password) {
+function handlePasswordFocusoutCheck(password) {
 	if (password === "") {
 		handlePasswordHint(INPUT_STATUS.isNotFilled);
 	} else {
@@ -151,12 +151,12 @@ function handleSignIn(email, password) {
 
 emailInputElement.addEventListener("focusout", () => {
 	const emailValue = emailInputElement.value;
-	checkEmailInputValue(emailValue);
+	handleEmailFocusoutCheck(emailValue);
 });
 
 passwordInputElement.addEventListener("focusout", () => {
 	const passwordValue = passwordInputElement.value;
-	checkPasswordInputValue(passwordValue);
+	handlePasswordFocusoutCheck(passwordValue);
 });
 
 signInButtonElement.addEventListener("click", (e) => {

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -171,11 +171,11 @@ function signIn(email, password) {
 }
 
 emailInputElement.addEventListener("focusout", (e) => {
-	checkEmailFocusout(emailInputElement.value);
+	checkEmailFocusout(e.target.value);
 });
 
-passwordInputElement.addEventListener("focusout", () => {
-	checkPasswordFocusout(passwordInputElement.value);
+passwordInputElement.addEventListener("focusout", (e) => {
+	checkPasswordFocusout(e.target.value);
 });
 
 signInButtonElement.addEventListener("click", (e) => {

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -49,10 +49,12 @@ passwordConfirmToggle?.addEventListener("click", () => {
 });
 
 // Signin 유효성 검사
-const SIGNIN_CURRECT = {
-	email: "test@codeit.com",
-	password: "codeit101",
-};
+const USERS = [
+	{
+		email: "test@codeit.com",
+		password: "codeit101",
+	},
+];
 const SIGNIN_HINT = {
 	email: {
 		default: "",
@@ -138,7 +140,7 @@ function handleSignIn(email, password) {
 		handleEmailHint(INPUT_STATUS.isNotFilled);
 	} else if (!EMAIL_PATTERN.test(email)) {
 		handleEmailHint(INPUT_STATUS.isNotValidated);
-	} else if (email !== SIGNIN_CURRECT.email) {
+	} else if (email !== USERS[0].email) {
 		handleEmailHint(INPUT_STATUS.isNotUser);
 	} else {
 		isEmailRight = true;
@@ -146,7 +148,7 @@ function handleSignIn(email, password) {
 
 	if (password === "") {
 		handlePasswordHint(INPUT_STATUS.isNotFilled);
-	} else if (password !== SIGNIN_CURRECT.password) {
+	} else if (password !== USERS[0].password) {
 		handlePasswordHint(INPUT_STATUS.isNotUser);
 	} else {
 		isPasswordRight = true;

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -67,6 +67,12 @@ const SIGNIN_HINT = {
 	},
 };
 const EMAIL_PATTERN = /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
+const INPUT_STATUS = {
+	default: "default",
+	isNotFilled: "isNotFilled",
+	isNotValidated: "isNotValidated",
+	iaNotUser: "isNotUser",
+};
 
 const emailInputElement = document.querySelector(".auth__input-email");
 const passwordInputElement = document.querySelector(".auth__input-password");
@@ -76,7 +82,7 @@ const passwordHintElement = document.querySelector(".auth__password-hint");
 
 function handleEmailHint(hintType) {
 	emailHintElement.innerText = SIGNIN_HINT.email[hintType];
-	if (hintType === "default") {
+	if (hintType === INPUT_STATUS.default) {
 		emailInputElement.classList.remove("auth__input--hint");
 	} else if (
 		emailInputElement.classList.contains("auth__input--hint") === false
@@ -104,19 +110,19 @@ function handleSigninSuccess() {
 
 function checkEmailInputValue(email) {
 	if (email === "") {
-		handleEmailHint("isNotFilled");
+		handleEmailHint(INPUT_STATUS.isNotFilled);
 	} else if (EMAIL_PATTERN.test(email) === false) {
-		handleEmailHint("isNotValidated");
+		handleEmailHint(INPUT_STATUS.isNotValidated);
 	} else {
-		handleEmailHint("default");
+		handleEmailHint(INPUT_STATUS.default);
 	}
 }
 
 function checkPasswordInputValue(password) {
 	if (password === "") {
-		handlePasswordHint("isNotFilled");
+		handlePasswordHint(INPUT_STATUS.isNotFilled);
 	} else {
-		handlePasswordHint("default");
+		handlePasswordHint(INPUT_STATUS.default);
 	}
 }
 
@@ -125,19 +131,19 @@ function handleSignIn(email, password) {
 	let isPasswordRight = false;
 
 	if (email === "") {
-		handleEmailHint("isNotFilled");
+		handleEmailHint(INPUT_STATUS.isNotFilled);
 	} else if (EMAIL_PATTERN.test(email) === false) {
-		handleEmailHint("isNotValidated");
+		handleEmailHint(INPUT_STATUS.isNotValidated);
 	} else if (email !== SIGNIN_CURRECT.email) {
-		handleEmailHint("isNotUser");
+		handleEmailHint(INPUT_STATUS.isNotUser);
 	} else {
 		isEmailRight = true;
 	}
 
 	if (password === "") {
-		handlePasswordHint("isNotFilled");
+		handlePasswordHint(INPUT_STATUS.isNotFilled);
 	} else if (password !== SIGNIN_CURRECT.password) {
-		handlePasswordHint("isNotUser");
+		handlePasswordHint(INPUT_STATUS.isNotUser);
 	} else {
 		isPasswordRight = true;
 	}

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -85,8 +85,7 @@ const emailHintElement = document.querySelector(".auth__email-hint");
 const passwordHintElement = document.querySelector(".auth__password-hint");
 
 function changeEmailHint(hintType) {
-	const hintText = emailHintElement.innerText;
-	if (hintText === SIGNIN_HINT.email[hintType]) return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
+	if (emailHintElement.innerText === SIGNIN_HINT.email[hintType]) return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
 	emailHintElement.innerText = SIGNIN_HINT.email[hintType];
 
 	if (hintType === INPUT_STATUS.default) {
@@ -97,8 +96,7 @@ function changeEmailHint(hintType) {
 }
 
 function changePasswordHint(hintType) {
-	const hintText = passwordHintElement.innerText;
-	if (hintText === SIGNIN_HINT.password[hintType]) return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
+	if (passwordHintElement.innerText === SIGNIN_HINT.password[hintType]) return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
 	passwordHintElement.innerText = SIGNIN_HINT.password[hintType];
 
 	if (hintType === INPUT_STATUS.default) {
@@ -173,18 +171,14 @@ function signIn(email, password) {
 }
 
 emailInputElement.addEventListener("focusout", (e) => {
-	const emailValue = emailInputElement.value;
-	checkEmailFocusout(emailValue);
+	checkEmailFocusout(emailInputElement.value);
 });
 
 passwordInputElement.addEventListener("focusout", () => {
-	const passwordValue = passwordInputElement.value;
-	checkPasswordFocusout(passwordValue);
+	checkPasswordFocusout(passwordInputElement.value);
 });
 
 signInButtonElement.addEventListener("click", (e) => {
 	e.preventDefault();
-	const emailValue = emailInputElement.value;
-	const passwordValue = passwordInputElement.value;
-	signIn(emailValue, passwordValue);
+	signIn(emailInputElement.value, passwordInputElement.value);
 });

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -86,24 +86,24 @@ const passwordHintElement = document.querySelector(".auth__password-hint");
 
 function handleEmailHint(hintType) {
 	const hintText = emailHintElement.innerText;
-	if (hintText === SIGNIN_HINT.email[hintType]) return;
-
+	if (hintText === SIGNIN_HINT.email[hintType]) return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
 	emailHintElement.innerText = SIGNIN_HINT.email[hintType];
+
 	if (hintType === INPUT_STATUS.default) {
 		emailInputElement.classList.remove(INPUT_HINT_CLASSNAME);
-	} else if (!emailInputElement.classList.contains(INPUT_HINT_CLASSNAME)) {
+	} else {
 		emailInputElement.classList.add(INPUT_HINT_CLASSNAME);
 	}
 }
 
 function handlePasswordHint(hintType) {
 	const hintText = passwordHintElement.innerText;
-	if (hintText === SIGNIN_HINT.password[hintType]) return;
-
+	if (hintText === SIGNIN_HINT.password[hintType]) return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
 	passwordHintElement.innerText = SIGNIN_HINT.password[hintType];
+
 	if (hintType === INPUT_STATUS.default) {
 		passwordInputElement.classList.remove(INPUT_HINT_CLASSNAME);
-	} else if (!passwordInputElement.classList.contains(INPUT_HINT_CLASSNAME)) {
+	} else {
 		passwordInputElement.classList.add(INPUT_HINT_CLASSNAME);
 	}
 }
@@ -148,16 +148,21 @@ function getIsUserEmail(email) {
 	}
 }
 
-function getIsUserPassword(password) {
-	if (password === "") {
-		handlePasswordHint(INPUT_STATUS.isNotFilled);
-		return false;
-	} else if (password !== USERS[0].password) {
-		handlePasswordHint(INPUT_STATUS.isNotUser);
-		return false;
+function getIsUserPassword(password, isUserEmail) {
+	if (isUserEmail) {
+		if (password === "") {
+			handlePasswordHint(INPUT_STATUS.isNotFilled);
+			return false;
+		} else if (password !== USERS[0].password) {
+			handlePasswordHint(INPUT_STATUS.isNotUser);
+			return false;
+		} else {
+			handlePasswordHint(INPUT_STATUS.default);
+			return true;
+		}
 	} else {
-		handlePasswordHint(INPUT_STATUS.default);
-		return true;
+		handlePasswordFocusoutCheck(password);
+		return false;
 	}
 }
 

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -76,7 +76,7 @@ const INPUT_STATUS = {
 
 const emailInputElement = document.querySelector(".auth__input-email");
 const passwordInputElement = document.querySelector(".auth__input-password");
-const signInButtonElement = document.querySelector(".signin__buton");
+const signInButtonElement = document.querySelector(".signin__button");
 const emailHintElement = document.querySelector(".auth__email-hint");
 const passwordHintElement = document.querySelector(".auth__password-hint");
 

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -73,6 +73,8 @@ const INPUT_STATUS = {
 	isNotValidated: "isNotValidated",
 	iaNotUser: "isNotUser",
 };
+const INPUT_HINT_CLASSNAME = "auth__input--hint";
+const FOLDER_PAGE_PATH = "/pages/forder.html";
 
 const emailInputElement = document.querySelector(".auth__input-email");
 const passwordInputElement = document.querySelector(".auth__input-password");
@@ -83,25 +85,25 @@ const passwordHintElement = document.querySelector(".auth__password-hint");
 function handleEmailHint(hintType) {
 	emailHintElement.innerText = SIGNIN_HINT.email[hintType];
 	if (hintType === INPUT_STATUS.default) {
-		emailInputElement.classList.remove("auth__input--hint");
-	} else if (!emailInputElement.classList.contains("auth__input--hint")) {
-		emailInputElement.classList.add("auth__input--hint");
+		emailInputElement.classList.remove(INPUT_HINT_CLASSNAME);
+	} else if (!emailInputElement.classList.contains(INPUT_HINT_CLASSNAME)) {
+		emailInputElement.classList.add(INPUT_HINT_CLASSNAME);
 	}
 }
 
 function handlePasswordHint(hintType) {
 	passwordHintElement.innerText = SIGNIN_HINT.password[hintType];
-	if (hintType === "default") {
-		passwordInputElement.classList.remove("auth__input--hint");
-	} else if (!passwordInputElement.classList.contains("auth__input--hint")) {
-		passwordInputElement.classList.add("auth__input--hint");
+	if (hintType === INPUT_STATUS.default) {
+		passwordInputElement.classList.remove(INPUT_HINT_CLASSNAME);
+	} else if (!passwordInputElement.classList.contains(INPUT_HINT_CLASSNAME)) {
+		passwordInputElement.classList.add(INPUT_HINT_CLASSNAME);
 	}
 }
 
 function handleSigninSuccess() {
-	emailInputElement.classList.remove("auth__input--hint");
-	passwordInputElement.classList.remove("auth__input--hint");
-	location.href = "/pages/forder.html";
+	emailInputElement.classList.remove(INPUT_HINT_CLASSNAME);
+	passwordInputElement.classList.remove(INPUT_HINT_CLASSNAME);
+	location.href = FOLDER_PAGE_PATH;
 }
 
 function checkEmailInputValue(email) {

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -1,4 +1,4 @@
-// SignIn, SignUp 비밀번호 토글
+// Signin, Signup 비밀번호 토글
 const PASSWORD_TOGGLE_CONSTANT = {
 	visible: {
 		inputType: "text",
@@ -48,7 +48,7 @@ passwordConfirmToggle?.addEventListener("click", () => {
 	passwordConfirmIcon.alt = passwordVisibility.imageAlt;
 });
 
-// SignIn 유효성 검사
+// Signin 유효성 검사
 const USERS = [
 	{
 		email: "test@codeit.com",
@@ -80,7 +80,7 @@ const FOLDER_PAGE_PATH = "/pages/forder.html";
 
 const emailInputElement = document.querySelector(".auth__input-email");
 const passwordInputElement = document.querySelector(".auth__input-password");
-const signInButtonElement = document.querySelector(".signIn__button");
+const signinButtonElement = document.querySelector(".signin__button");
 const emailHintElement = document.querySelector(".auth__email-hint");
 const passwordHintElement = document.querySelector(".auth__password-hint");
 
@@ -106,7 +106,7 @@ function changePasswordHint(hintType) {
 	}
 }
 
-function handleSignInSuccess() {
+function signinSuccess() {
 	emailInputElement.classList.remove(INPUT_HINT_CLASSNAME);
 	passwordInputElement.classList.remove(INPUT_HINT_CLASSNAME);
 	location.href = FOLDER_PAGE_PATH;
@@ -146,28 +146,24 @@ function getIsUserEmail(email) {
 	}
 }
 
-function getIsUserPassword(password, isUserEmail) {
-	if (isUserEmail) {
-		if (password === "") {
-			changePasswordHint(INPUT_STATUS.isNotFilled);
-			return false;
-		} else if (password !== USERS[0].password) {
-			changePasswordHint(INPUT_STATUS.isNotUser);
-			return false;
-		} else {
-			changePasswordHint(INPUT_STATUS.default);
-			return true;
-		}
-	} else {
-		checkPasswordFocusout(password);
+function getIsUserPassword(password) {
+	if (password === "") {
+		changePasswordHint(INPUT_STATUS.isNotFilled);
 		return false;
+	} else if (password !== USERS[0].password) {
+		changePasswordHint(INPUT_STATUS.isNotUser);
+		return false;
+	} else {
+		changePasswordHint(INPUT_STATUS.default);
+		return true;
 	}
 }
 
-function signIn(email, password) {
+function clickSignin(email, password) {
 	const isUserEmail = getIsUserEmail(email);
+	if (!isUserEmail) return; // 유저 이메일이 아닌경우 비밀번호 검사하지 않고 리턴
 	const isUserPassword = getIsUserPassword(password);
-	if (isUserEmail && isUserPassword) handleSignInSuccess();
+	if (isUserEmail && isUserPassword) signinSuccess();
 }
 
 emailInputElement.addEventListener("focusout", (e) => {
@@ -178,7 +174,7 @@ passwordInputElement.addEventListener("focusout", (e) => {
 	checkPasswordFocusout(e.target.value);
 });
 
-signInButtonElement.addEventListener("click", (e) => {
+signinButtonElement.addEventListener("click", (e) => {
 	e.preventDefault();
-	signIn(emailInputElement.value, passwordInputElement.value);
+	clickSignin(emailInputElement.value, passwordInputElement.value);
 });

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -1,4 +1,4 @@
-// Signin, Signup 비밀번호 토글
+// SignIn, SignUp 비밀번호 토글
 const PASSWORD_TOGGLE_CONSTANT = {
 	visible: {
 		inputType: "text",
@@ -48,7 +48,7 @@ passwordConfirmToggle?.addEventListener("click", () => {
 	passwordConfirmIcon.alt = passwordVisibility.imageAlt;
 });
 
-// Signin 유효성 검사
+// SignIn 유효성 검사
 const USERS = [
 	{
 		email: "test@codeit.com",
@@ -80,11 +80,11 @@ const FOLDER_PAGE_PATH = "/pages/forder.html";
 
 const emailInputElement = document.querySelector(".auth__input-email");
 const passwordInputElement = document.querySelector(".auth__input-password");
-const signInButtonElement = document.querySelector(".signin__button");
+const signInButtonElement = document.querySelector(".signIn__button");
 const emailHintElement = document.querySelector(".auth__email-hint");
 const passwordHintElement = document.querySelector(".auth__password-hint");
 
-function handleEmailHint(hintType) {
+function changeEmailHint(hintType) {
 	const hintText = emailHintElement.innerText;
 	if (hintText === SIGNIN_HINT.email[hintType]) return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
 	emailHintElement.innerText = SIGNIN_HINT.email[hintType];
@@ -96,7 +96,7 @@ function handleEmailHint(hintType) {
 	}
 }
 
-function handlePasswordHint(hintType) {
+function changePasswordHint(hintType) {
 	const hintText = passwordHintElement.innerText;
 	if (hintText === SIGNIN_HINT.password[hintType]) return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
 	passwordHintElement.innerText = SIGNIN_HINT.password[hintType];
@@ -108,42 +108,42 @@ function handlePasswordHint(hintType) {
 	}
 }
 
-function handleSigninSuccess() {
+function handleSignInSuccess() {
 	emailInputElement.classList.remove(INPUT_HINT_CLASSNAME);
 	passwordInputElement.classList.remove(INPUT_HINT_CLASSNAME);
 	location.href = FOLDER_PAGE_PATH;
 }
 
-function handleEmailFocusoutCheck(email) {
+function checkEmailFocusout(email) {
 	if (email === "") {
-		handleEmailHint(INPUT_STATUS.isNotFilled);
+		changeEmailHint(INPUT_STATUS.isNotFilled);
 	} else if (!EMAIL_PATTERN.test(email)) {
-		handleEmailHint(INPUT_STATUS.isNotValidated);
+		changeEmailHint(INPUT_STATUS.isNotValidated);
 	} else {
-		handleEmailHint(INPUT_STATUS.default);
+		changeEmailHint(INPUT_STATUS.default);
 	}
 }
 
-function handlePasswordFocusoutCheck(password) {
+function checkPasswordFocusout(password) {
 	if (password === "") {
-		handlePasswordHint(INPUT_STATUS.isNotFilled);
+		changePasswordHint(INPUT_STATUS.isNotFilled);
 	} else {
-		handlePasswordHint(INPUT_STATUS.default);
+		changePasswordHint(INPUT_STATUS.default);
 	}
 }
 
 function getIsUserEmail(email) {
 	if (email === "") {
-		handleEmailHint(INPUT_STATUS.isNotFilled);
+		changeEmailHint(INPUT_STATUS.isNotFilled);
 		return false;
 	} else if (!EMAIL_PATTERN.test(email)) {
-		handleEmailHint(INPUT_STATUS.isNotValidated);
+		changeEmailHint(INPUT_STATUS.isNotValidated);
 		return false;
 	} else if (email !== USERS[0].email) {
-		handleEmailHint(INPUT_STATUS.isNotUser);
+		changeEmailHint(INPUT_STATUS.isNotUser);
 		return false;
 	} else {
-		handleEmailHint(INPUT_STATUS.default);
+		changeEmailHint(INPUT_STATUS.default);
 		return true;
 	}
 }
@@ -151,40 +151,40 @@ function getIsUserEmail(email) {
 function getIsUserPassword(password, isUserEmail) {
 	if (isUserEmail) {
 		if (password === "") {
-			handlePasswordHint(INPUT_STATUS.isNotFilled);
+			changePasswordHint(INPUT_STATUS.isNotFilled);
 			return false;
 		} else if (password !== USERS[0].password) {
-			handlePasswordHint(INPUT_STATUS.isNotUser);
+			changePasswordHint(INPUT_STATUS.isNotUser);
 			return false;
 		} else {
-			handlePasswordHint(INPUT_STATUS.default);
+			changePasswordHint(INPUT_STATUS.default);
 			return true;
 		}
 	} else {
-		handlePasswordFocusoutCheck(password);
+		checkPasswordFocusout(password);
 		return false;
 	}
 }
 
-function handleSignIn(email, password) {
+function signIn(email, password) {
 	const isUserEmail = getIsUserEmail(email);
 	const isUserPassword = getIsUserPassword(password);
-	if (isUserEmail && isUserPassword) handleSigninSuccess();
+	if (isUserEmail && isUserPassword) handleSignInSuccess();
 }
 
 emailInputElement.addEventListener("focusout", (e) => {
 	const emailValue = emailInputElement.value;
-	handleEmailFocusoutCheck(emailValue);
+	checkEmailFocusout(emailValue);
 });
 
 passwordInputElement.addEventListener("focusout", () => {
 	const passwordValue = passwordInputElement.value;
-	handlePasswordFocusoutCheck(passwordValue);
+	checkPasswordFocusout(passwordValue);
 });
 
 signInButtonElement.addEventListener("click", (e) => {
 	e.preventDefault();
 	const emailValue = emailInputElement.value;
 	const passwordValue = passwordInputElement.value;
-	handleSignIn(emailValue, passwordValue);
+	signIn(emailValue, passwordValue);
 });

--- a/utils/signin.js
+++ b/utils/signin.js
@@ -1,0 +1,127 @@
+import {
+	passwordToggleElement,
+	getPasswordVisibility,
+	USERS,
+	AUTH_HINT,
+	EMAIL_PATTERN,
+	INPUT_STATUS,
+	INPUT_HINT_CLASSNAME,
+	FOLDER_PAGE_PATH,
+} from "/utils/auth.js";
+
+/* 비밀번호 토글 */
+// 이벤트 핸들러
+passwordToggleElement.addEventListener("click", () => {
+	const passwordInput = document.querySelector(".auth__input-password");
+	const passwordIcon = document.querySelector(".auth__icon-password");
+
+	const passwordVisibility = getPasswordVisibility(passwordInput.type);
+
+	passwordInput.type = passwordVisibility.inputType;
+	passwordIcon.src = passwordVisibility.imageSrc;
+	passwordIcon.alt = passwordVisibility.imageAlt;
+});
+
+/* 유효성 검사 */
+// DOM 요소
+const emailInputElement = document.querySelector(".auth__input-email");
+const passwordInputElement = document.querySelector(".auth__input-password");
+const emailHintElement = document.querySelector(".auth__email-hint");
+const passwordHintElement = document.querySelector(".auth__password-hint");
+const signinButtonElement = document.querySelector(".signin__button");
+
+// 함수
+function changeEmailHint(hintType) {
+	if (emailHintElement.innerText === AUTH_HINT.email[hintType]) return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
+	emailHintElement.innerText = AUTH_HINT.email[hintType];
+
+	if (hintType === INPUT_STATUS.default) {
+		emailInputElement.classList.remove(INPUT_HINT_CLASSNAME);
+	} else {
+		emailInputElement.classList.add(INPUT_HINT_CLASSNAME);
+	}
+}
+
+function changePasswordHint(hintType) {
+	if (passwordHintElement.innerText === AUTH_HINT.password[hintType]) return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
+	passwordHintElement.innerText = AUTH_HINT.password[hintType];
+
+	if (hintType === INPUT_STATUS.default) {
+		passwordInputElement.classList.remove(INPUT_HINT_CLASSNAME);
+	} else {
+		passwordInputElement.classList.add(INPUT_HINT_CLASSNAME);
+	}
+}
+
+// 함수
+function checkEmailFocusout(email) {
+	if (email === "") {
+		changeEmailHint(INPUT_STATUS.isNotFilled);
+	} else if (!EMAIL_PATTERN.test(email)) {
+		changeEmailHint(INPUT_STATUS.isNotValidated);
+	} else {
+		changeEmailHint(INPUT_STATUS.default);
+	}
+}
+
+function checkPasswordFocusout(password) {
+	if (password === "") {
+		changePasswordHint(INPUT_STATUS.isNotFilled);
+	} else {
+		changePasswordHint(INPUT_STATUS.default);
+	}
+}
+
+function getIsUserEmail(email) {
+	if (email === "") {
+		changeEmailHint(INPUT_STATUS.isNotFilled);
+		return false;
+	} else if (!EMAIL_PATTERN.test(email)) {
+		changeEmailHint(INPUT_STATUS.isNotValidated);
+		return false;
+	} else if (email !== USERS[0].email) {
+		changeEmailHint(INPUT_STATUS.isNotExists);
+		return false;
+	} else {
+		changeEmailHint(INPUT_STATUS.default);
+		return true;
+	}
+}
+
+function getIsUserPassword(password) {
+	if (password === "") {
+		changePasswordHint(INPUT_STATUS.isNotFilled);
+		return false;
+	} else if (password !== USERS[0].password) {
+		changePasswordHint(INPUT_STATUS.isNotExists);
+		return false;
+	} else {
+		changePasswordHint(INPUT_STATUS.default);
+		return true;
+	}
+}
+
+function signinSuccess() {
+	location.href = FOLDER_PAGE_PATH;
+}
+
+function clickSignin(email, password) {
+	const isUserEmail = getIsUserEmail(email);
+	if (!isUserEmail) return checkPasswordFocusout(password); // TODO 유저 이메일이 아닌경우 비밀번호 입력 여부만 검사하고 리턴
+	const isUserPassword = getIsUserPassword(password);
+	if (isUserEmail && isUserPassword) signinSuccess();
+}
+
+// 이벤트 핸들러 등록
+emailInputElement.addEventListener("focusout", (e) => {
+	checkEmailFocusout(e.target.value);
+});
+
+passwordInputElement.addEventListener("focusout", (e) => {
+	checkPasswordFocusout(e.target.value);
+});
+
+signinButtonElement.addEventListener("click", (e) => {
+	e.preventDefault();
+	clickSignin(emailInputElement.value, passwordInputElement.value);
+});

--- a/utils/signup.js
+++ b/utils/signup.js
@@ -1,0 +1,209 @@
+import {
+	passwordToggleElement,
+	getPasswordVisibility,
+	USERS,
+	AUTH_HINT,
+	EMAIL_PATTERN,
+	INPUT_STATUS,
+	INPUT_HINT_CLASSNAME,
+	FOLDER_PAGE_PATH,
+} from "/utils/auth.js";
+
+/* 비밀번호 토글 */
+// DOM 요소
+const passwordConfirmToggleElement = document.querySelector(
+	".auth__toggle-password--confirm"
+);
+const passwordConfirmInputElement = document.querySelector(
+	".auth__input-password--confirm"
+);
+const passwordConfirmIconElement = document.querySelector(
+	".auth__icon-password--confirm"
+);
+
+// 핸들러
+passwordToggleElement.addEventListener("click", () => {
+	const passwordInput = document.querySelector(".auth__input-password");
+	const passwordIcon = document.querySelector(".auth__icon-password");
+
+	const passwordVisibility = getPasswordVisibility(passwordInput.type);
+
+	passwordInput.type = passwordVisibility.inputType;
+	passwordIcon.src = passwordVisibility.imageSrc;
+	passwordIcon.alt = passwordVisibility.imageAlt;
+});
+
+passwordConfirmToggleElement.addEventListener("click", () => {
+	const passwordVisibility = getPasswordVisibility(
+		passwordConfirmInputElement.type
+	);
+
+	passwordConfirmInputElement.type = passwordVisibility.inputType;
+	passwordConfirmIconElement.src = passwordVisibility.imageSrc;
+	passwordConfirmIconElement.alt = passwordVisibility.imageAlt;
+});
+
+/* 유효성 검사 */
+// 상수
+const PASSWORD_PATTERN = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/;
+
+// DOM 요소
+const emailInputElement = document.querySelector(".auth__input-email");
+const passwordInputElement = document.querySelector(".auth__input-password");
+const emailHintElement = document.querySelector(".auth__email-hint");
+const passwordHintElement = document.querySelector(".auth__password-hint");
+const passwordConfirmHintElement = document.querySelector(
+	".auth__password-hint--confirm"
+);
+const signupButtonElement = document.querySelector(".signup__button");
+
+// 함수
+function changeEmailHint(hintType) {
+	if (emailHintElement.innerText === AUTH_HINT.email[hintType]) return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
+	emailHintElement.innerText = AUTH_HINT.email[hintType];
+
+	if (hintType === INPUT_STATUS.default) {
+		emailInputElement.classList.remove(INPUT_HINT_CLASSNAME);
+	} else {
+		emailInputElement.classList.add(INPUT_HINT_CLASSNAME);
+	}
+}
+
+function changePasswordHint(hintType) {
+	if (passwordHintElement.innerText === AUTH_HINT.password[hintType]) return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
+	passwordHintElement.innerText = AUTH_HINT.password[hintType];
+
+	if (hintType === INPUT_STATUS.default) {
+		passwordInputElement.classList.remove(INPUT_HINT_CLASSNAME);
+	} else {
+		passwordInputElement.classList.add(INPUT_HINT_CLASSNAME);
+	}
+}
+
+function changePasswordConfirmHint(hintType) {
+	if (passwordConfirmHintElement.innerText === AUTH_HINT.password[hintType])
+		return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
+	passwordConfirmHintElement.innerText = AUTH_HINT.password[hintType];
+
+	if (hintType === INPUT_STATUS.default) {
+		passwordConfirmInputElement.classList.remove(INPUT_HINT_CLASSNAME);
+	} else {
+		passwordConfirmInputElement.classList.add(INPUT_HINT_CLASSNAME);
+	}
+}
+function checkEmailFocusout(email) {
+	if (email === "") {
+		changeEmailHint(INPUT_STATUS.isNotFilled);
+	} else if (!EMAIL_PATTERN.test(email)) {
+		changeEmailHint(INPUT_STATUS.isNotValidated);
+	} else if (email === USERS[0].email) {
+		changeEmailHint(INPUT_STATUS.isExists);
+	} else {
+		changeEmailHint(INPUT_STATUS.default);
+	}
+}
+
+function checkPasswordFocusout(password) {
+	if (password === "") {
+		changePasswordHint(INPUT_STATUS.isNotFilled);
+	} else if (!PASSWORD_PATTERN.test(password)) {
+		changePasswordHint(INPUT_STATUS.isNotValidated);
+	} else {
+		changePasswordHint(INPUT_STATUS.default);
+	}
+}
+
+function checkPasswordConfirmFocusout(passwordConfirm) {
+	console.log(passwordConfirm, passwordInputElement.value);
+	if (passwordConfirm === "") {
+		changePasswordConfirmHint(INPUT_STATUS.isNotFilled);
+	} else if (passwordConfirm !== passwordInputElement.value) {
+		changePasswordConfirmHint(INPUT_STATUS.isNotConfirmed);
+	} else {
+		changePasswordConfirmHint(INPUT_STATUS.default);
+	}
+}
+
+function getIsValidatedEmail(email) {
+	if (email === "") {
+		changeEmailHint(INPUT_STATUS.isNotFilled);
+		return false;
+	} else if (!EMAIL_PATTERN.test(email)) {
+		changeEmailHint(INPUT_STATUS.isNotValidated);
+		return false;
+	} else if (email === USERS[0].email) {
+		changeEmailHint(INPUT_STATUS.isExists);
+		return false;
+	} else {
+		changeEmailHint(INPUT_STATUS.default);
+		return true;
+	}
+}
+
+function getIsValidatedPassword(password) {
+	if (password === "") {
+		changePasswordHint(INPUT_STATUS.isNotFilled);
+		return false;
+	} else if (!PASSWORD_PATTERN.test(password)) {
+		changePasswordHint(INPUT_STATUS.isNotValidated);
+		return false;
+	} else {
+		changePasswordHint(INPUT_STATUS.default);
+		return true;
+	}
+}
+
+function getIsConfirmedPassword(passwordConfirm) {
+	console.log(passwordConfirm, passwordInputElement.value);
+	if (passwordConfirm === "") {
+		changePasswordConfirmHint(INPUT_STATUS.isNotFilled);
+		return false;
+	} else if (passwordConfirm !== passwordInputElement.value) {
+		changePasswordConfirmHint(INPUT_STATUS.isNotConfirmed);
+		return false;
+	} else {
+		return true;
+	}
+}
+
+function signupSuccess() {
+	location.href = FOLDER_PAGE_PATH;
+}
+
+function clickSignup(email, password, passwordConfirm) {
+	const isValidatedEmail = getIsValidatedEmail(email);
+	const isValidatedPassword = getIsValidatedPassword(password);
+	const isConfirmedPassword = getIsConfirmedPassword(passwordConfirm);
+
+	if (isValidatedEmail && isValidatedPassword && isConfirmedPassword)
+		signupSuccess();
+}
+
+emailInputElement.addEventListener("focusout", (e) => {
+	checkEmailFocusout(e.target.value);
+});
+
+passwordInputElement.addEventListener("focusout", (e) => {
+	checkPasswordFocusout(e.target.value);
+});
+
+passwordConfirmInputElement.addEventListener("focusout", (e) => {
+	checkPasswordConfirmFocusout(e.target.value);
+});
+
+emailInputElement.addEventListener("focusout", (e) => {
+	checkEmailFocusout(e.target.value);
+});
+
+passwordInputElement.addEventListener("focusout", (e) => {
+	checkPasswordFocusout(e.target.value);
+});
+
+signupButtonElement.addEventListener("click", (e) => {
+	e.preventDefault();
+	clickSignup(
+		emailInputElement.value,
+		passwordInputElement.value,
+		passwordConfirmInputElement.value
+	);
+});


### PR DESCRIPTION
## 요구사항

### 기본
- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 일 때, input 값이 [test@codeit.com](mailto:test@codeit.com) 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] 이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화
- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?


## 주요 변경사항
- 4주차 미션 리팩토링
- 5주차 미션


## 멘토에게
- [노션 링크](https://narrow-wrist-63f.notion.site/5-_-4cbd451b238640ba840350f5c26fee7e?pvs=4)
