### PR TITLE
[이슬] week6

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "liveServer.settings.port": 5501
+}

--- a/api/auth.js
+++ b/api/auth.js
@@ -1,0 +1,16 @@
+const BASE_URL = "https://bootcamp-api.codeit.kr";
+
+export async function signIn(email, password) {
+  const response = await fetch(`${BASE_URL}/api/sign-in`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      email,
+      password,
+    }),
+  });
+
+  return response;
+}

--- a/signin/signin.js
+++ b/signin/signin.js
@@ -70,6 +70,8 @@ loginBtn.addEventListener("click", async function () {
     }),
   });
 
+  const responseData = await response.json();
+
   if (response.status === 200) {
     // 로그인 성공
     localStorage.setItem("accessToken", responseData.accessToken); // accessToken 저장

--- a/signin/signin.js
+++ b/signin/signin.js
@@ -51,13 +51,28 @@ function checkPasswordInput() {
 emailInput.addEventListener("blur", checkEmailValidity);
 passwordInput.addEventListener("blur", checkPasswordInput);
 
-loginBtn.addEventListener("click", function () {
+loginBtn.addEventListener("click", async function () {
   const email = emailInput.value;
   const password = passwordInput.value;
 
-  if (email === "test@codeit.com" && password === "codeit101") {
+  const response = await fetch("https://bootcamp-api.codeit.kr/api/sign-in", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      email: email,
+      password: password,
+    }),
+  });
+
+  const responseData = await response.json();
+
+  if (response.status === 200) {
+    // 로그인 성공
     location.href = "/folder";
-  } else {
+  } else if (response.status === 400) {
+    // 로그인 오류
     displayError(emailInput, emailErrorText, EMAIL_VERIFY);
     displayError(passwordInput, passwordErrorText, PASSWORD_VERIFY);
   }

--- a/signin/signin.js
+++ b/signin/signin.js
@@ -2,6 +2,7 @@ import {
   displayError,
   resetErrorMessage,
   togglePasswordVisibility,
+  redirectToFolderIfAuthenticated,
 } from "/utils/common.js";
 import { isValidEmail } from "/utils/validation.js";
 import {
@@ -22,9 +23,7 @@ const {
 } = ERROR_MESSAGES;
 import { signIn } from "/api/auth.js";
 
-if (localStorage.getItem("accessToken")) {
-  location.href = "/folder";
-}
+redirectToFolderIfAuthenticated();
 
 const emailInput = document.querySelector(USERNAME_SELECTOR);
 const passwordInput = document.querySelector(PASSWORD_SELECTOR);

--- a/signin/signin.js
+++ b/signin/signin.js
@@ -21,6 +21,10 @@ const {
   PASSWORD_VERIFY,
 } = ERROR_MESSAGES;
 
+if (localStorage.getItem("accessToken")) {
+  location.href = "/folder";
+}
+
 const emailInput = document.querySelector(USERNAME_SELECTOR);
 const passwordInput = document.querySelector(PASSWORD_SELECTOR);
 const loginBtn = document.querySelector(LOGIN_BTN_SELECTOR);
@@ -66,10 +70,9 @@ loginBtn.addEventListener("click", async function () {
     }),
   });
 
-  const responseData = await response.json();
-
   if (response.status === 200) {
     // 로그인 성공
+    localStorage.setItem("accessToken", responseData.accessToken); // accessToken 저장
     location.href = "/folder";
   } else if (response.status === 400) {
     // 로그인 오류

--- a/signin/signin.js
+++ b/signin/signin.js
@@ -20,6 +20,7 @@ const {
   EMAIL_VERIFY,
   PASSWORD_VERIFY,
 } = ERROR_MESSAGES;
+import { signIn } from "/api/auth.js";
 
 if (localStorage.getItem("accessToken")) {
   location.href = "/folder";
@@ -59,17 +60,7 @@ loginBtn.addEventListener("click", async function () {
   const email = emailInput.value;
   const password = passwordInput.value;
 
-  const response = await fetch("https://bootcamp-api.codeit.kr/api/sign-in", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      email: email,
-      password: password,
-    }),
-  });
-
+  const response = await signIn(email, password);
   const responseData = await response.json();
 
   if (response.status === 200) {

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -2,6 +2,7 @@ import {
   displayError,
   resetErrorMessage,
   togglePasswordVisibility,
+  redirectToFolderIfAuthenticated,
 } from "/utils/common.js";
 import { isValidEmail, isValidPassword } from "/utils/validation.js";
 import {
@@ -25,10 +26,7 @@ const {
   PASSWORD_REQUIREMENTS,
 } = ERROR_MESSAGES;
 
-// 페이지 접근 시 accessToken 확인하고 있으면 /folder로 이동
-if (localStorage.getItem("accessToken")) {
-  window.location.href = "/folder";
-}
+redirectToFolderIfAuthenticated();
 
 const emailInput = document.querySelector(USERNAME_SELECTOR);
 const passwordInput = document.querySelector(PASSWORD_SELECTOR);

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -25,6 +25,11 @@ const {
   PASSWORD_REQUIREMENTS,
 } = ERROR_MESSAGES;
 
+// 페이지 접근 시 accessToken 확인하고 있으면 /folder로 이동
+if (localStorage.getItem("accessToken")) {
+  window.location.href = "/folder";
+}
+
 const emailInput = document.querySelector(USERNAME_SELECTOR);
 const passwordInput = document.querySelector(PASSWORD_SELECTOR);
 const passwordCheckInput = document.querySelector(PASSWORD_CHECK_SELECTOR);
@@ -131,8 +136,12 @@ async function submitForm() {
         }
       );
 
+      const responseData = await response.json();
+
       if (response.status === 200) {
         // 회원가입 성공
+        // 회원가입 성공
+        localStorage.setItem("accessToken", responseData.accessToken);
         window.location.href = "/folder";
       }
     } catch (error) {

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -43,13 +43,16 @@ const toggleVisibility = document.querySelectorAll(TOGGLE_VISIBILITY_SELECTOR);
 
 async function isEmailTaken(email) {
   try {
-    const response = await fetch("https://bootcamp-api.codeit.kr/api/sign-up", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ email }),
-    });
+    const response = await fetch(
+      "https://bootcamp-api.codeit.kr/api/check-email",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email }),
+      }
+    );
 
     if (response.status === 409) {
       return true; // 중복된 이메일
@@ -139,7 +142,6 @@ async function submitForm() {
       const responseData = await response.json();
 
       if (response.status === 200) {
-        // 회원가입 성공
         // 회원가입 성공
         localStorage.setItem("accessToken", responseData.accessToken);
         window.location.href = "/folder";

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -36,7 +36,28 @@ const passwordCheckErrorText = document.querySelector(
 );
 const toggleVisibility = document.querySelectorAll(TOGGLE_VISIBILITY_SELECTOR);
 
-function checkEmailValidity() {
+async function isEmailTaken(email) {
+  try {
+    const response = await fetch("https://bootcamp-api.codeit.kr/api/sign-up", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email }),
+    });
+
+    if (response.status === 409) {
+      return true; // 중복된 이메일
+    } else if (response.status === 200) {
+      return false; // 중복되지 않은 이메일
+    }
+  } catch (error) {
+    console.error("이메일 중복 체크 에러: ", error);
+    return false;
+  }
+}
+
+async function checkEmailValidity() {
   const email = emailInput.value;
   if (!email) {
     displayError(emailInput, emailErrorText, EMAIL_EMPTY);
@@ -44,7 +65,7 @@ function checkEmailValidity() {
   } else if (!isValidEmail(email)) {
     displayError(emailInput, emailErrorText, EMAIL_INVALID);
     return false;
-  } else if (email === "test@codeit.com") {
+  } else if (await isEmailTaken(email)) {
     displayError(emailInput, emailErrorText, EMAIL_TAKEN);
     return false;
   } else {

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -88,9 +88,35 @@ passwordCheckInput.addEventListener("keydown", function (event) {
   }
 });
 
-function submitForm() {
-  if (checkEmailValidity() && checkPasswordValidity() && checkPasswordMatch()) {
-    window.location.href = "/folder";
+async function submitForm() {
+  const isEmailValid = checkEmailValidity();
+  const isPasswordValid = checkPasswordValidity();
+  const isPasswordMatching = checkPasswordMatch();
+
+  // 유효성 검사를 모두 통과한 경우만 API 요청을 수행
+  if (isEmailValid && isPasswordValid && isPasswordMatching) {
+    try {
+      const response = await fetch(
+        "https://bootcamp-api.codeit.kr/api/sign-up",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            email: emailInput.value,
+            password: passwordInput.value,
+          }),
+        }
+      );
+
+      if (response.status === 200) {
+        // 회원가입 성공
+        window.location.href = "/folder";
+      }
+    } catch (error) {
+      console.error("error:", error);
+    }
   }
 }
 

--- a/utils/common.js
+++ b/utils/common.js
@@ -24,3 +24,9 @@ export function togglePasswordVisibility(inputElement, toggleElement) {
     toggleElement.src = "/assets/eye-off.svg";
   }
 }
+
+export function redirectToFolderIfAuthenticated() {
+  if (localStorage.getItem("accessToken")) {
+    window.location.href = "/folder";
+  }
+}


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [로그인 페이지] https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “test@codeit.com”, “password”: “sprint101” } POST 요청해서 성공 응답을 받고 “/folder”로 이동하나요?
- [x] [회원가입 페이지] 이메일 input에서 “test@codeit.com”으로 “/api/check-email” 이메일 중복 확인 POST 요청하면 이메일 중복 에러를 확인할 수 있나요?
- [x] [회원가입 페이지] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?

### 심화

- [x] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?
- [x] 로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 “/folder” 페이지로 이동하나요?

## 주요 변경사항

- 로그인, 회원가입 페이지에서 필요한 api 요청을 보냅니다.
- 로그인/회원가입시 성공 응답으로 받은 accessToken을 로컬 스토리지에 저장합니다.
- 로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 “/folder” 페이지로 이동합니다.

## 멘토에게
- try catch는 무조건 사용하는 게 좋은거겠죠..?!
