### PR TITLE
[박소현] Week6

### DIFF
--- a/Linkbrary/signin.html
+++ b/Linkbrary/signin.html
@@ -6,6 +6,7 @@
     <title>Signin Page</title>
     <link rel="stylesheet" href="css/reset.css" />
     <link rel="stylesheet" href="css/sign_form.css" />
+    <script type="module" src="src/common/auth/withAuth.js" defer></script>
     <script type="module" src="src/signin.js" defer></script>
     <script type="module" src="src/common/utils/hiddenPassword.js" defer></script>
   </head>

--- a/Linkbrary/signup.html
+++ b/Linkbrary/signup.html
@@ -6,6 +6,7 @@
     <title>Signup Page</title>
     <link rel="stylesheet" href="css/reset.css" />
     <link rel="stylesheet" href="css/sign_form.css" />
+    <script type="module" src="./src/common/auth/withAuth.js" defer></script>
     <script type="module" src="./src/signup.js" defer></script>
     <script type="module" src="src/common/utils/hiddenPassword.js" defer></script>
   </head>

--- a/Linkbrary/src/common/auth/withAuth.js
+++ b/Linkbrary/src/common/auth/withAuth.js
@@ -1,0 +1,4 @@
+// 로컬스토리지에 accessToken이 있는지 확인
+const accessToken = localStorage.getItem("accessToken");
+
+if (accessToken) location.href = "folder.html";

--- a/Linkbrary/src/common/constants/api.js
+++ b/Linkbrary/src/common/constants/api.js
@@ -1,0 +1,4 @@
+const API_URL = "https://bootcamp-api.codeit.kr";
+const APPLICATION_JSON_TYPE = "application/json; charset=utf-8";
+
+export { API_URL, APPLICATION_JSON_TYPE };

--- a/Linkbrary/src/common/constants/endpoints.js
+++ b/Linkbrary/src/common/constants/endpoints.js
@@ -1,0 +1,10 @@
+const user = {
+  CHECK_EMAIL: "/api/check-email",
+};
+
+const auth = {
+  SIGN_IN: "/api/sign-in",
+  SIGN_UP: "/api/sign-up",
+};
+
+export { user, auth };

--- a/Linkbrary/src/common/utils/emailValidationCheck.js
+++ b/Linkbrary/src/common/utils/emailValidationCheck.js
@@ -22,12 +22,22 @@ export const isEmailValidation = (value) => {
 };
 
 /* 이메일 중복 검증 */
-const USER_EMAIL = "test@codeit.com";
+export const isDuplicateEmail = async (value) => {
+  try {
+    const res = await fetch("https://bootcamp-api.codeit.kr/api/check-email", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({ email: value }),
+    });
 
-export const isDuplicateEmail = (value) => {
-  if (value === USER_EMAIL) {
-    emailErrorEl.textContent = "이미 사용 중인 이메일입니다.";
-    return true;
+    if (!res.ok) {
+      emailErrorEl.textContent = "이미 사용 중인 이메일입니다.";
+      return true;
+    }
+    return false;
+  } catch (error) {
+    console.log(error.message);
   }
-  return false;
 };

--- a/Linkbrary/src/common/utils/emailValidationCheck.js
+++ b/Linkbrary/src/common/utils/emailValidationCheck.js
@@ -1,3 +1,5 @@
+import { user } from "../constants/endpoints.js";
+import { API_URL, APPLICATION_JSON_TYPE } from "../constants/api.js";
 import { emailErrorEl } from "../constants/elements.js";
 
 /* 이메일 유효성 검사 */
@@ -24,10 +26,10 @@ export const isEmailValidation = (value) => {
 /* 이메일 중복 검증 */
 export const isDuplicateEmail = async (value) => {
   try {
-    const res = await fetch("https://bootcamp-api.codeit.kr/api/check-email", {
+    const res = await fetch(`${API_URL}${user.CHECK_EMAIL}`, {
       method: "POST",
       headers: {
-        "Content-Type": "application/json; charset=utf-8",
+        "Content-Type": APPLICATION_JSON_TYPE,
       },
       body: JSON.stringify({ email: value }),
     });

--- a/Linkbrary/src/signin.js
+++ b/Linkbrary/src/signin.js
@@ -1,4 +1,7 @@
+import { auth } from "./common/constants/endpoints.js";
+import { API_URL, APPLICATION_JSON_TYPE } from "./common/constants/api.js";
 import { formEl, emailEl, passwordEl, emailErrorEl, passwordErrorEl } from "./common/constants/elements.js";
+
 import { isEmailEmpty, isEmailValidation } from "./common/utils/emailValidationCheck.js";
 import { isPasswordEmpty } from "./common/utils/passwordValidationCheck.js";
 
@@ -46,10 +49,10 @@ const onClickSubmit = async (e) => {
   if (!emailInputValidation(emailEl.value) || !passwordInputValidation(passwordEl.value)) return;
 
   try {
-    const res = await fetch("https://bootcamp-api.codeit.kr/api/sign-in", {
+    const res = await fetch(`${API_URL}${auth.SIGN_IN}`, {
       method: "POST",
       headers: {
-        "Content-Type": "application/json; charset=utf-8",
+        "Content-Type": APPLICATION_JSON_TYPE,
       },
       body: JSON.stringify({
         email: emailEl.value,

--- a/Linkbrary/src/signin.js
+++ b/Linkbrary/src/signin.js
@@ -2,9 +2,6 @@ import { formEl, emailEl, passwordEl, emailErrorEl, passwordErrorEl } from "./co
 import { isEmailEmpty, isEmailValidation } from "./common/utils/emailValidationCheck.js";
 import { isPasswordEmpty } from "./common/utils/passwordValidationCheck.js";
 
-const USER_EMAIL = "test@codeit.com";
-const USER_PASSWORD = "codeit101";
-
 const addErrorClass = (el) => el.classList.add("error");
 const removeErrorClass = (el) => el.classList.remove("error");
 
@@ -43,20 +40,38 @@ const checkFormValue = (e) => {
 };
 
 /** 이메일, 비밀번호가 매치되는 로그인 시도할 경우, “/folder” 페이지로 이동  */
-const onClickSubmit = (e) => {
+const onClickSubmit = async (e) => {
   e.preventDefault();
 
   if (!emailInputValidation(emailEl.value) || !passwordInputValidation(passwordEl.value)) return;
 
-  /** 이외의 로그인 시도의 경우, 이메일 input, 비밀번호 input 아래에 해당 에러 메세지 */
-  if (emailEl.value !== USER_EMAIL || passwordEl.value !== USER_PASSWORD) {
-    emailErrorEl.textContent = "이메일을 확인해주세요";
-    passwordErrorEl.textContent = "비밀번호를 확인해주세요";
-    addErrorClass(emailEl);
-    addErrorClass(passwordEl);
-    return;
+  try {
+    const res = await fetch("https://bootcamp-api.codeit.kr/api/sign-in", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({
+        email: emailEl.value,
+        password: passwordEl.value,
+      }),
+    });
+
+    if (!res.ok) {
+      emailErrorEl.textContent = "이메일을 확인해주세요";
+      passwordErrorEl.textContent = "비밀번호를 확인해주세요";
+      addErrorClass(emailEl);
+      addErrorClass(passwordEl);
+      return;
+    }
+
+    const result = await res.json();
+    const accessToken = result.data.accessToken;
+    localStorage.setItem("accessToken", accessToken);
+    formEl.submit();
+  } catch (error) {
+    console.log(error);
   }
-  formEl.submit();
 };
 
 formEl.addEventListener("focusout", checkFormValue);

--- a/Linkbrary/src/signup.js
+++ b/Linkbrary/src/signup.js
@@ -62,15 +62,37 @@ const checkFormValue = (e) => {
 };
 
 /*유효한 회원가입 시도의 경우, “/folder”로 이동 */
-const onClickSubmit = (e) => {
+const onClickSubmit = async (e) => {
   e.preventDefault();
 
   if (
-    emailInputValidation(emailEl.value) &&
-    passwordInputValidation(passwordEl.value) &&
-    passwordCheckInputValidation(passwordCheckEl.value)
+    !emailInputValidation(emailEl.value) ||
+    !passwordInputValidation(passwordEl.value) ||
+    !passwordCheckInputValidation(passwordCheckEl.value)
   )
-    formEl.submit();
+    return;
+
+  try {
+    const res = await fetch("https://bootcamp-api.codeit.kr/api/sign-up", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({
+        email: emailEl.value,
+        password: passwordEl.value,
+      }),
+    });
+
+    if (res.ok) {
+      const result = await res.json();
+      const accessToken = result.data.accessToken;
+      localStorage.setItem("accessToken", accessToken);
+      formEl.submit();
+    }
+  } catch (error) {
+    console.log(error);
+  }
 };
 
 formEl.addEventListener("focusout", checkFormValue);

--- a/Linkbrary/src/signup.js
+++ b/Linkbrary/src/signup.js
@@ -15,8 +15,8 @@ const addErrorClass = (el) => el.classList.add("error");
 const removeErrorClass = (el) => el.classList.remove("error");
 
 /* 이메일 유효성 검사 */
-const emailInputValidation = (value) => {
-  if (isEmailEmpty(value) || isEmailValidation(value) || isDuplicateEmail(value)) {
+const emailInputValidation = async (value) => {
+  if (isEmailEmpty(value) || isEmailValidation(value) || (await isDuplicateEmail(value))) {
     addErrorClass(emailEl);
     return false;
   }

--- a/Linkbrary/src/signup.js
+++ b/Linkbrary/src/signup.js
@@ -1,3 +1,5 @@
+import { auth } from "./common/constants/endpoints.js";
+import { API_URL, APPLICATION_JSON_TYPE } from "./common/constants/api.js";
 import {
   emailEl,
   emailErrorEl,
@@ -73,10 +75,10 @@ const onClickSubmit = async (e) => {
     return;
 
   try {
-    const res = await fetch("https://bootcamp-api.codeit.kr/api/sign-up", {
+    const res = await fetch(`${API_URL}${auth.SIGN_UP}`, {
       method: "POST",
       headers: {
-        "Content-Type": "application/json; charset=utf-8",
+        "Content-Type": APPLICATION_JSON_TYPE,
       },
       body: JSON.stringify({
         email: emailEl.value,


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [로그인 페이지] https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “test@codeit.com”, “password”: “sprint101” } POST 요청해서 성공 응답을 받고 “/folder”로 이동하나요?
- [x] [회원가입 페이지] 이메일 input에서 “test@codeit.com”으로 “/api/check-email” 이메일 중복 확인 POST 요청하면 이메일 중복 에러를 확인할 수 있나요?
- [x] [회원가입 페이지] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?

### 심화

- [x] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?
- [x] 로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 “/folder” 페이지로 이동하나요?


## 주요 변경사항

- signin, signup 페이지 api연동
- accessToken 로컬스토리지에 저장
- api 관련 endpoint, api url을 상수로 분리
- accessToken 여부 검증 코드 분리

## 멘토에게

- 에러 처리, 공통으로 분리하는 작업 등 올바르게 처리하였는지 궁금합니다.
- 그동안 피드백 해주셔서 감사드립니다. 😊
