### PR TITLE
[손지은] week6

### DIFF
--- a/script/sign.js
+++ b/script/sign.js
@@ -1,7 +1,5 @@
 const $emailErrorMessage = document.querySelector('.email_error_message');
-const $pwdErrorMessage = document.querySelector('.pwd_error_message');
 const $email = document.querySelector('.email_input');
-const $pwd = document.querySelector('.pwd_input');
 
 export let emailValid = false;
 export let pwdValid = false;
@@ -20,16 +18,7 @@ export function emailErrorMessage(){
     emailValid = true;
    }
 }
-export function pwdErrorMessage(){
-    pwdValid=false;
-    if($pwd.value === ""){
-        showErrorMessage($pwd,$pwdErrorMessage,"비밀번호를 입력해주세요.");
-    }
-    else{
-        removeErrorMessage($pwd,$pwdErrorMessage);
-        pwdValid = true;
-    }
-}
+
 export function showErrorMessage($input,$errorMessage, message){
     $errorMessage.textContent = message;
     $errorMessage.style.display = "block";

--- a/script/sign.js
+++ b/script/sign.js
@@ -1,4 +1,4 @@
-export const CODEIT = "https://bootcamp-api.codeit.kr"
+export const CODEIT = "https://bootcamp-api.codeit.kr/api"
 export let emailValid = false;
 
 const REGEMAIL = /^[A-Za-z0-9\-]+@[A-Za-z0-9]+\.[a-z]/;

--- a/script/sign.js
+++ b/script/sign.js
@@ -2,59 +2,53 @@ const $emailErrorMessage = document.querySelector('.email_error_message');
 const $pwdErrorMessage = document.querySelector('.pwd_error_message');
 const $email = document.querySelector('.email_input');
 const $pwd = document.querySelector('.pwd_input');
-const $pwdEye = document.querySelectorAll('.password-eye');
 
-let emailValid = false;
-let pwdValid = false;
+export let emailValid = false;
+export let pwdValid = false;
 
 const REGEMAIL = /^[A-Za-z0-9\-]+@[A-Za-z0-9]+\.[a-z]/;
-function emailErrorMessage(){
+export function emailErrorMessage(){
     emailValid = false;
     if($email.value === ""){
-        $emailErrorMessage.textContent = "이메일을 입력해주세요."
-        $emailErrorMessage.style.display ="block";
-        $email.classList.add('border-red');
+        showErrorMessage($email,$emailErrorMessage,"이메일을 입력해주세요.")
     }
    else if(!REGEMAIL.test($email.value)){
-        $emailErrorMessage.textContent = "올바른 이메일 주소가 아닙니다."
-        $emailErrorMessage.style.display ="block";
-        $email.classList.add('border-red');
+        showErrorMessage($email,$emailErrorMessage,"올바른 이메일 주소가 아닙니다.")
    }
    else{
-    $emailErrorMessage.style.display ="none";
-    $email.classList.remove("border-red");
+    removeErrorMessage($email, $emailErrorMessage);
     emailValid = true;
    }
 }
-$email.addEventListener("focusout",emailErrorMessage);
-
-
-function pwdErrorMessage(){
+export function pwdErrorMessage(){
     pwdValid=false;
     if($pwd.value === ""){
-        $pwdErrorMessage.textContent = "비밀번호를 입력해주세요."
-        $pwdErrorMessage.style.display ="block";
-        $pwd.classList.add('border-red');
+        showErrorMessage($pwd,$pwdErrorMessage,"비밀번호를 입력해주세요.");
     }
     else{
-        $pwdErrorMessage.style.display ="none";
-        $pwd.classList.remove("border-red");
+        removeErrorMessage($pwd,$pwdErrorMessage);
         pwdValid = true;
     }
 }
-$pwd.addEventListener("focusout",pwdErrorMessage);
+export function showErrorMessage($input,$errorMessage, message){
+    $errorMessage.textContent = message;
+    $errorMessage.style.display = "block";
+    $input.classList.add('border-red');
+}
 
-function pwdEyeOnOff(e){
-    let eyeOn = e.target.src.includes('eye-on');
+export function removeErrorMessage($input,$errorMessage){
+    $errorMessage.style.display = "none";
+    $input.classList.remove('border-red');
+}
+
+export function pwdEyeOnOff($target,$input){
+    let eyeOn = $target.src.includes('eye-on');
     if(eyeOn){
-        e.target.src = "/img/eye-off.svg";
-        e.target.previousElementSibling.type ="password";
+        $target.src = "/img/eye-off.svg";
+        $input.type ="password";
     }
     else{
-        e.target.src = "/img/eye-on.svg";
-        e.target.previousElementSibling.type ="text";
+        $target.src = "/img/eye-on.svg";
+        $input.type ="text";
     }
 }
-$pwdEye[0].addEventListener('click',pwdEyeOnOff);
-
-export {$email,$emailErrorMessage,$pwdErrorMessage,$pwd,pwdEyeOnOff,$pwdEye,emailValid,pwdValid,emailErrorMessage,pwdErrorMessage}

--- a/script/sign.js
+++ b/script/sign.js
@@ -1,20 +1,16 @@
-const $emailErrorMessage = document.querySelector('.email_error_message');
-const $email = document.querySelector('.email_input');
-
 export let emailValid = false;
-export let pwdValid = false;
 
 const REGEMAIL = /^[A-Za-z0-9\-]+@[A-Za-z0-9]+\.[a-z]/;
-export function emailErrorMessage(){
+export function emailErrorMessage($input,$errorMessage){
     emailValid = false;
-    if($email.value === ""){
-        showErrorMessage($email,$emailErrorMessage,"이메일을 입력해주세요.")
+    if($input.value === ""){
+        showErrorMessage($input,$errorMessage,"이메일을 입력해주세요.")
     }
-   else if(!REGEMAIL.test($email.value)){
-        showErrorMessage($email,$emailErrorMessage,"올바른 이메일 주소가 아닙니다.")
+   else if(!REGEMAIL.test($input.value)){
+        showErrorMessage($input,$errorMessage,"올바른 이메일 주소가 아닙니다.")
    }
    else{
-    removeErrorMessage($email, $emailErrorMessage);
+    removeErrorMessage($input, $errorMessage);
     emailValid = true;
    }
 }

--- a/script/sign.js
+++ b/script/sign.js
@@ -1,3 +1,4 @@
+export const CODEIT = "https://bootcamp-api.codeit.kr"
 export let emailValid = false;
 
 const REGEMAIL = /^[A-Za-z0-9\-]+@[A-Za-z0-9]+\.[a-z]/;

--- a/script/signin.js
+++ b/script/signin.js
@@ -39,7 +39,7 @@ async function signinValidCheck(e){
                 "email" : $email.value,
                 "password" : $pwd.value
             }
-            const response = await fetch(`${CODEIT}/api/sign-in`,{
+            const response = await fetch(`${CODEIT}/sign-in`,{
                 method : "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/script/signin.js
+++ b/script/signin.js
@@ -50,8 +50,9 @@ async function signinValidCheck(e){
                   },
                 body : JSON.stringify(user)
             });
+            const signinResponse = await response.json()
             if(response.status == 200){
-                localStorage.setItem("accessToken",signupResponse.data.accessToken)
+                localStorage.setItem("accessToken",signinResponse.data.accessToken)
                 location.href = '/folder'
             }
             else if(response.status == 400){

--- a/script/signin.js
+++ b/script/signin.js
@@ -3,7 +3,8 @@ import {
     emailErrorMessage,
     pwdEyeOnOff,
     showErrorMessage,
-    removeErrorMessage
+    removeErrorMessage,
+    CODEIT
 
 } from './sign.js';
 
@@ -38,7 +39,7 @@ async function signinValidCheck(e){
                 "email" : $email.value,
                 "password" : $pwd.value
             }
-            const response = await fetch("https://bootcamp-api.codeit.kr/api/sign-in",{
+            const response = await fetch(`${CODEIT}/api/sign-in`,{
                 method : "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/script/signin.js
+++ b/script/signin.js
@@ -1,20 +1,37 @@
-import {$emailErrorMessage,$pwdErrorMessage,pwdErrorMessage,emailValid,pwdValid, emailErrorMessage} from './sign.js';
+import {
+    pwdErrorMessage,
+    emailValid,
+    pwdValid,
+    emailErrorMessage,
+    pwdEyeOnOff,
+    showErrorMessage,
 
+} from './sign.js';
+
+const $emailErrorMessage = document.querySelector('.email_error_message');
+const $pwdErrorMessage = document.querySelector('.pwd_error_message');
+const $email = document.querySelector('.email_input');
+const $pwdEye = document.querySelector('.password-eye');
 const $submit = document.querySelector('.form__sign');
+const $pwd = document.querySelector('.pwd_input');
+
+$email.addEventListener("focusout",emailErrorMessage);
+$pwd.addEventListener("focusout",pwdErrorMessage);
+$pwdEye.addEventListener('click',(e)=>pwdEyeOnOff(e.target,$pwd));
+
 function signinValidCheck(e){
+    emailErrorMessage();
+    pwdErrorMessage();
     if(emailValid && pwdValid){
         return;
     }
     if(!emailValid){
-        $emailErrorMessage.textContent = "이메일을 확인해주세요."
+        showErrorMessage($email,$emailErrorMessage, "이메일을 확인해주세요.");
         e.preventDefault();
     }
     if(!pwdValid){
-        $pwdErrorMessage.textContent = "비밀번호를 확인해주세요."
-        $pwdErrorMessage.style.display ="block";
+        showErrorMessage($pwd,$pwdErrorMessage,"비밀번호를 확인해주세요.");
         e.preventDefault();
     }
 }
 $submit.addEventListener('submit',signinValidCheck);
-$submit.addEventListener('submit',pwdErrorMessage);
-$submit.addEventListener('submit',emailErrorMessage);

--- a/script/signin.js
+++ b/script/signin.js
@@ -46,14 +46,16 @@ async function signinValidCheck(e){
                   },
                 body : JSON.stringify(user)
             });
-            const postResponse = await response.json();
-            if(postResponse.error)
-                throw new Error('bad Request')
-            else
+            if(response.status == 200)
                 location.href = '/folder';
-        }catch{
-            showErrorMessage($email,$emailErrorMessage, "이메일을 확인해주세요.");
-            showErrorMessage($pwd,$pwdErrorMessage,"비밀번호를 확인해주세요.");
+            else if(response.status == 400){
+                showErrorMessage($email,$emailErrorMessage, "이메일을 확인해주세요.");
+                showErrorMessage($pwd,$pwdErrorMessage,"비밀번호를 확인해주세요.");
+            }
+            else
+                throw new Error(`${response.status}`);
+        }catch(err){
+            console.log(err)
         }
     }
 }

--- a/script/signin.js
+++ b/script/signin.js
@@ -14,7 +14,7 @@ const $pwdEye = document.querySelector('.password-eye');
 const $submit = document.querySelector('.form__sign');
 const $pwd = document.querySelector('.pwd_input');
 
-$email.addEventListener("focusout",emailErrorMessage);
+$email.addEventListener("focusout",(e)=>emailErrorMessage(e.target,$emailErrorMessage));
 $pwdEye.addEventListener('click',(e)=>pwdEyeOnOff(e.target,$pwd));
 
 let pwdValid = false;
@@ -31,8 +31,6 @@ function pwdErrorMessage(){
 $pwd.addEventListener("focusout",pwdErrorMessage);
 
 function signinValidCheck(e){
-    emailErrorMessage();
-    pwdErrorMessage();
     if(emailValid && pwdValid){
         return;
     }

--- a/script/signin.js
+++ b/script/signin.js
@@ -30,17 +30,30 @@ function pwdErrorMessage(){
 }
 $pwd.addEventListener("focusout",pwdErrorMessage);
 
-function signinValidCheck(e){
+async function signinValidCheck(e){
+    e.preventDefault();
     if(emailValid && pwdValid){
-        return;
-    }
-    if(!emailValid){
-        showErrorMessage($email,$emailErrorMessage, "이메일을 확인해주세요.");
-        e.preventDefault();
-    }
-    if(!pwdValid){
-        showErrorMessage($pwd,$pwdErrorMessage,"비밀번호를 확인해주세요.");
-        e.preventDefault();
+        try{
+            const user = {
+                "email" : $email.value,
+                "password" : $pwd.value
+            }
+            const response = await fetch("https://bootcamp-api.codeit.kr/api/sign-in",{
+                method : "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                  },
+                body : JSON.stringify(user)
+            });
+            const postResponse = await response.json();
+            if(postResponse.error)
+                throw new Error('bad Request')
+            else
+                location.href = '/folder';
+        }catch{
+            showErrorMessage($email,$emailErrorMessage, "이메일을 확인해주세요.");
+            showErrorMessage($pwd,$pwdErrorMessage,"비밀번호를 확인해주세요.");
+        }
     }
 }
 $submit.addEventListener('submit',signinValidCheck);

--- a/script/signin.js
+++ b/script/signin.js
@@ -1,10 +1,9 @@
 import {
-    pwdErrorMessage,
     emailValid,
-    pwdValid,
     emailErrorMessage,
     pwdEyeOnOff,
     showErrorMessage,
+    removeErrorMessage
 
 } from './sign.js';
 
@@ -16,8 +15,20 @@ const $submit = document.querySelector('.form__sign');
 const $pwd = document.querySelector('.pwd_input');
 
 $email.addEventListener("focusout",emailErrorMessage);
-$pwd.addEventListener("focusout",pwdErrorMessage);
 $pwdEye.addEventListener('click',(e)=>pwdEyeOnOff(e.target,$pwd));
+
+let pwdValid = false;
+function pwdErrorMessage(){
+    pwdValid=false;
+    if($pwd.value === ""){
+        showErrorMessage($pwd,$pwdErrorMessage,"비밀번호를 입력해주세요.");
+    }
+    else{
+        removeErrorMessage($pwd,$pwdErrorMessage);
+        pwdValid = true;
+    }
+}
+$pwd.addEventListener("focusout",pwdErrorMessage);
 
 function signinValidCheck(e){
     emailErrorMessage();

--- a/script/signin.js
+++ b/script/signin.js
@@ -18,6 +18,10 @@ const $pwd = document.querySelector('.pwd_input');
 $email.addEventListener("focusout",(e)=>emailErrorMessage(e.target,$emailErrorMessage));
 $pwdEye.addEventListener('click',(e)=>pwdEyeOnOff(e.target,$pwd));
 
+if(localStorage.getItem("accessToken")){
+    location.href = '/folder';
+}
+
 let pwdValid = false;
 function pwdErrorMessage(){
     pwdValid=false;
@@ -46,8 +50,10 @@ async function signinValidCheck(e){
                   },
                 body : JSON.stringify(user)
             });
-            if(response.status == 200)
-                location.href = '/folder';
+            if(response.status == 200){
+                localStorage.setItem("accessToken",signupResponse.data.accessToken)
+                location.href = '/folder'
+            }
             else if(response.status == 400){
                 showErrorMessage($email,$emailErrorMessage, "이메일을 확인해주세요.");
                 showErrorMessage($pwd,$pwdErrorMessage,"비밀번호를 확인해주세요.");

--- a/script/signup.js
+++ b/script/signup.js
@@ -24,7 +24,7 @@ $pwdEyes[1].addEventListener('click',(e)=>pwdEyeOnOff(e.target,$pwdCheck));
 let emailDupliValid = false;
 async function emailDuplication(){
     try{
-        const response = await fetch(`${CODEIT}/api/check-emaisl`,{
+        const response = await fetch(`${CODEIT}/check-emaisl`,{
             method : 'POST',
             headers:{
                 "Content-Type": "application/json",
@@ -73,10 +73,34 @@ function pwdCheck(){
 
 $pwdCheck.addEventListener("focusout", pwdCheck);
 
-function validCheck(e){
-    if(pwdValid && pwdCheckValid && emailValid&&emailDupliValid)
-        return;
-    else
-      e.preventDefault();
+async function validCheck(e){
+    e.preventDefault();
+    if(pwdValid && pwdCheckValid && emailValid&&emailDupliValid){
+        try{
+           const user = {
+            "email" : $email.value,
+            "password" : $pwd.value
+            }
+            const response = await fetch(`${CODEIT}/sign-up`,{
+                method : 'POST',
+                body: JSON.stringify(user)
+            });
+            const signupResponse = await response.json()
+            if(response.status == 200){
+                localStorage.setItem("accessToken",signupResponse.data.accessToken)
+                location.href = '/folder'
+            }
+            else if(response.status == 400){
+                console.log(response);
+            }
+            else
+                throw new Error(`${response.status}`)
+        }catch(err){
+            console.log(err);
+
+        }
+        
+    }
+        
 }
 $submit.addEventListener("submit",validCheck);

--- a/script/signup.js
+++ b/script/signup.js
@@ -4,6 +4,7 @@ import {
     emailErrorMessage,
     showErrorMessage,
     removeErrorMessage,
+    CODEIT,
 } from './sign.js';
 
 const $pwdErrorMessage = document.querySelector('.pwd_error_message');
@@ -21,14 +22,25 @@ $pwdEyes[1].addEventListener('click',(e)=>pwdEyeOnOff(e.target,$pwdCheck));
 
 
 let emailDupliValid = false;
-function emailDuplication(){
-    const existEmail = 'test@codeit.com'
-    if($email.value === existEmail){
+async function emailDuplication(){
+    try{
+        const response = await fetch(`${CODEIT}/api/check-email`,{
+            method : 'POST',
+            headers:{
+                "Content-Type": "application/json",
+            },
+            body : JSON.stringify({"email" : $email.value})
+        })
+        const emailResponse = await response.json();
+        if(response.status == 409)
+            throw new Error(`${emailResponse.error.message}`)
+        else if(response.status == 200)
+            emailDupliValid = true;
+    }catch(error){
+        console.log(error.message)
         showErrorMessage($email,$emailErrorMessage,"이미 사용 중인 이메일입니다.");
         emailDupliValid = false;
     }
-    else
-        emailDupliValid = true;
 }
 $email.addEventListener("focusout", emailDuplication);
 

--- a/script/signup.js
+++ b/script/signup.js
@@ -37,6 +37,7 @@ let pwdValid = false;
 function pwdValidation(){
     if(!REGPWD.test($pwd.value)){
         showErrorMessage($pwd,$pwdErrorMessage,"비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요.");
+        pwdValid = false;
     }
     else{
         removeErrorMessage($pwd,$pwdErrorMessage);

--- a/script/signup.js
+++ b/script/signup.js
@@ -15,7 +15,7 @@ const $pwdEyes = document.querySelectorAll('.password-eye');
 const $email = document.querySelector('.email_input');
 const $pwd = document.querySelector('.pwd_input');
 
-$email.addEventListener("focusout",emailErrorMessage);
+$email.addEventListener("focusout",(e)=>emailErrorMessage(e.target,$emailErrorMessage));
 $pwdEyes[0].addEventListener('click',(e)=>pwdEyeOnOff(e.target,$pwd));
 $pwdEyes[1].addEventListener('click',(e)=>pwdEyeOnOff(e.target,$pwdCheck));
 
@@ -61,8 +61,6 @@ function pwdCheck(){
 $pwdCheck.addEventListener("focusout", pwdCheck);
 
 function validCheck(e){
-    emailErrorMessage();
-    pwdCheck();
     if(pwdValid && pwdCheckValid && emailValid&&emailDupliValid)
         return;
     else

--- a/script/signup.js
+++ b/script/signup.js
@@ -20,11 +20,14 @@ $email.addEventListener("focusout",(e)=>emailErrorMessage(e.target,$emailErrorMe
 $pwdEyes[0].addEventListener('click',(e)=>pwdEyeOnOff(e.target,$pwd));
 $pwdEyes[1].addEventListener('click',(e)=>pwdEyeOnOff(e.target,$pwdCheck));
 
+if(localStorage.getItem("accessToken")){
+    location.href = '/folder';
+}
 
 let emailDupliValid = false;
 async function emailDuplication(){
     try{
-        const response = await fetch(`${CODEIT}/check-emaisl`,{
+        const response = await fetch(`${CODEIT}/check-email`,{
             method : 'POST',
             headers:{
                 "Content-Type": "application/json",
@@ -82,8 +85,11 @@ async function validCheck(e){
             "password" : $pwd.value
             }
             const response = await fetch(`${CODEIT}/sign-up`,{
-                method : 'POST',
-                body: JSON.stringify(user)
+                method : "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                  },
+                body : JSON.stringify(user)
             });
             const signupResponse = await response.json()
             if(response.status == 200){

--- a/script/signup.js
+++ b/script/signup.js
@@ -26,6 +26,7 @@ if(localStorage.getItem("accessToken")){
 
 let emailDupliValid = false;
 async function emailDuplication(){
+    emailDupliValid = false;
     try{
         const response = await fetch(`${CODEIT}/check-email`,{
             method : 'POST',
@@ -36,7 +37,6 @@ async function emailDuplication(){
         })
         if(response.status == 409){
             showErrorMessage($email,$emailErrorMessage,"이미 사용 중인 이메일입니다.");
-            emailDupliValid = false;
         }
         else if(response.status == 200)
             emailDupliValid = true;
@@ -92,11 +92,11 @@ async function validCheck(e){
                 body : JSON.stringify(user)
             });
             const signupResponse = await response.json()
-            if(response.status == 200){
+            if(response.status === 200){
                 localStorage.setItem("accessToken",signupResponse.data.accessToken)
                 location.href = '/folder'
             }
-            else if(response.status == 400){
+            else if(response.status === 400){
                 console.log(response);
             }
             else

--- a/script/signup.js
+++ b/script/signup.js
@@ -24,22 +24,23 @@ $pwdEyes[1].addEventListener('click',(e)=>pwdEyeOnOff(e.target,$pwdCheck));
 let emailDupliValid = false;
 async function emailDuplication(){
     try{
-        const response = await fetch(`${CODEIT}/api/check-email`,{
+        const response = await fetch(`${CODEIT}/api/check-emaisl`,{
             method : 'POST',
             headers:{
                 "Content-Type": "application/json",
             },
             body : JSON.stringify({"email" : $email.value})
         })
-        const emailResponse = await response.json();
-        if(response.status == 409)
-            throw new Error(`${emailResponse.error.message}`)
+        if(response.status == 409){
+            showErrorMessage($email,$emailErrorMessage,"이미 사용 중인 이메일입니다.");
+            emailDupliValid = false;
+        }
         else if(response.status == 200)
             emailDupliValid = true;
-    }catch(error){
-        console.log(error.message)
-        showErrorMessage($email,$emailErrorMessage,"이미 사용 중인 이메일입니다.");
-        emailDupliValid = false;
+        else
+            throw new Error(`${response.status}`);
+    }catch(err){
+        console.log(err);
     }
 }
 $email.addEventListener("focusout", emailDuplication);

--- a/script/signup.js
+++ b/script/signup.js
@@ -1,16 +1,30 @@
-import {$email,$emailErrorMessage,$pwdErrorMessage,$pwd,pwdEyeOnOff,$pwdEye,emailValid, emailErrorMessage} from './sign.js';
+import {
+    pwdEyeOnOff,
+    emailValid,
+    emailErrorMessage,
+    showErrorMessage,
+    removeErrorMessage,
+} from './sign.js';
 
+const $pwdErrorMessage = document.querySelector('.pwd_error_message');
 const $pwdCheckErrorMessage = document.querySelector('.check_pwd_error_message');
+const $emailErrorMessage = document.querySelector('.email_error_message');
 const $pwdCheck = document.querySelector('.check_pwd_input');
 const $submit = document.querySelector('.form__sign');
+const $pwdEyes = document.querySelectorAll('.password-eye');
+const $email = document.querySelector('.email_input');
+const $pwd = document.querySelector('.pwd_input');
+
+$email.addEventListener("focusout",emailErrorMessage);
+$pwdEyes[0].addEventListener('click',(e)=>pwdEyeOnOff(e.target,$pwd));
+$pwdEyes[1].addEventListener('click',(e)=>pwdEyeOnOff(e.target,$pwdCheck));
+
 
 let emailDupliValid = false;
 function emailDuplication(){
     const existEmail = 'test@codeit.com'
     if($email.value === existEmail){
-        $emailErrorMessage.textContent = "이미 사용 중인 이메일입니다."
-        $emailErrorMessage.style.display ="block";
-        $email.classList.add('border-red');
+        showErrorMessage($email,$emailErrorMessage,"이미 사용 중인 이메일입니다.");
         emailDupliValid = false;
     }
     else
@@ -22,28 +36,23 @@ const REGPWD = /(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-Z0-9]{8,}/;
 let pwdValid = false;
 function pwdValidation(){
     if(!REGPWD.test($pwd.value)){
-        $pwdErrorMessage.textContent = "비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요."
-        $pwdErrorMessage.style.display ="block";
-        $pwd.classList.add('border-red');
+        showErrorMessage($pwd,$pwdErrorMessage,"비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요.");
     }
-    else
+    else{
+        removeErrorMessage($pwd,$pwdErrorMessage);
         pwdValid = true;
+    }
 }
 $pwd.addEventListener("focusout", pwdValidation);
-
-$pwdEye[1].addEventListener('click',pwdEyeOnOff);
 
 let pwdCheckValid = false;
 function pwdCheck(){
     if($pwdCheck.value === $pwd.value){
-        $pwdCheckErrorMessage.style.display ="none";
-        $pwdCheck.classList.remove('border-red');
+        removeErrorMessage($pwdCheck,$pwdCheckErrorMessage);
         pwdCheckValid=true;
     }
     else{
-        $pwdCheckErrorMessage.textContent = "비밀번호가 일치하지 않아요."
-        $pwdCheckErrorMessage.style.display ="block";
-        $pwdCheck.classList.add('border-red');
+        showErrorMessage($pwdCheck,$pwdCheckErrorMessage,"비밀번호가 일치하지 않아요.")
         pwdCheckValid=false;
     }
 }
@@ -51,13 +60,11 @@ function pwdCheck(){
 $pwdCheck.addEventListener("focusout", pwdCheck);
 
 function validCheck(e){
+    emailErrorMessage();
+    pwdCheck();
     if(pwdValid && pwdCheckValid && emailValid&&emailDupliValid)
         return;
     else
-      e.preventDefault();  
+      e.preventDefault();
 }
 $submit.addEventListener("submit",validCheck);
-$submit.addEventListener("submit",emailErrorMessage);
-$submit.addEventListener("submit",emailDuplication);
-$submit.addEventListener("submit",pwdCheck);
-$submit.addEventListener("submit",pwdValidation);


### PR DESCRIPTION
## 요구사항

### 기본
[로그인 페이지] 
- [x]  https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “test@codeit.com”, “password”: “sprint101” } POST 요청해서 성공 응답을 받고 “/folder”로 이동하나요?

[회원가입 페이지]
- [x] 이메일 input에서 “test@codeit.com”으로 “/api/check-email” 이메일 중복 확인 POST 요청하면 이메일 중복 에러를 확인할 수 있나요?
- [x] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?


### 심화

- [x] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?

- [x] 로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 “/folder” 페이지로 이동하나요?

## 주요 변경사항

- 함수형으로 리팩토링 중입니다.
-

## 스크린샷

https://jieun-linkbrary.netlify.app/html/signin.html

## 멘토에게

- 함수형으로 리팩토링중입니다. if문의 조건부분이 `$input.value === ""`이런식인데 이 부분도 함수로 바꿀지 이대로도 괜찮은지 고민입니다..
- `emailValid = false;` 로 유효성 검사를 하는데 비순수함수입니다. 이런 어쩔 수 없는 부분은 비순수함수로 놔둬도 괜찮을까요? 아니면 다른 방법이 있을까요?
- 회원가입시 중복이메일을 입력하면 
<img width="527" alt="스크린샷 2023-10-15 오전 11 49 28" src="https://github.com/codeit-bootcamp-frontend/1-Weekly-Mission/assets/144668146/d14cbb38-405f-4dee-93d1-418fd59c6f09">
이런 응답이 옵니다. 이것은 에러인가요..? try...catch에서 잡지 못하고, rejected인가 해서 봤는데 상태도 fulfilled입니다.

- Promise객체가 rejected인지 fulfilled인지 확인해보고 싶었습니다.
제가 작성한 코드 `const response = await fetch('')`에서 `console.log(response)`를 하면 response는 Promise객체가 아닌 그냥 객체입니다. 이런경우 Promise객체의 상태를 알 수 있는 방법이 있을까요?