### PR TITLE
[윤대호] week6

### DIFF
--- a/user/auth.css
+++ b/user/auth.css
@@ -89,7 +89,7 @@
 .form__input:focus {
 	outline-color: var(--linkbrary-primary-color);
 }
-.form__input--warning {
+.form__input--warning--active {
 	border-color: var(--linkbrary-red);
 }
 .form__eye-icon {
@@ -102,7 +102,7 @@
 .form__input--password {
 	padding-right: 2.125rem;
 }
-.form__warning-message {
+.form__warning-message--active {
 	color: var(--linkbrary-red);
 	font-family: Pretendard;
 	font-size: 0.875rem;

--- a/user/login.js
+++ b/user/login.js
@@ -1,45 +1,106 @@
 import {
-	ERROR_MSG,
-	USER,
+	API_URL,
+	VALID_STATUS,
+	USER_EMAIL,
+	USER_PASSWORD,
+	ERROR_ELEMENT_CLASS,
+	PASSWORD_VIEW_MODE,
+	updateInputDomError,
+	findElementFromCloestFormField,
+	togglePasswordInput,
+	handleInputError,
 	isAllInputsValid,
-	toggleError,
-	authForm,
-	formInputs,
-	submitButton,
-	inputsAndButton,
+	makeIsEmpty,
+	makeIsValid,
 } from "./auth.js";
 
-// --- 순수 함수 ---
-
-// 유저 정보 확인 임시
-const isValidUser = ([email, password]) => USER[email.value] === password.value;
-
-// --- 사이드 이펙트 함수들 ---
-
-// 존재하지 않는 사용자일 경우 에러메시지 보여주기
-const showInvalidUserError = (inputArr) =>
-	inputArr.forEach((input) => toggleError(input, ERROR_MSG[input.id].check));
-
-// 로그인 폼 전송
-const authFormLogin = () => {
-	formInputs.forEach((input) => toggleError(input));
-
-	if (!isAllInputsValid()) return;
-
-	if (!isValidUser(formInputs)) {
-		showInvalidUserError(formInputs);
-		return;
-	}
-
-	authForm.submit();
-};
-
-formInputs.forEach((input) => {
-	input.addEventListener("blur", (e) => toggleError(e.target));
-	input.addEventListener(
-		"keydown",
-		(e) => e.key === "Enter" && authFormLogin()
-	);
+//엑세스 토큰 있으면 바로 폴더로 이동
+window.addEventListener("DOMContentLoaded", function () {
+	localStorage.getItem("accessToken") && authForm.submit();
 });
 
-submitButton.addEventListener("click", authFormLogin);
+const isEmptyInput = makeIsEmpty();
+
+const handleAuthEvent = (e) => {
+	if (e.type === "keydown" && e.key !== "Enter") return;
+	if (!isAllInputsValid(VALID_STATUS)) return;
+	const authData = {
+		email: emailInput.value,
+		password: passwordInput.value,
+	};
+	const authJson = JSON.stringify(authData);
+	loginFormSubmit(API_URL.signIn, authJson);
+};
+
+const saveToken = (key, value) => localStorage.setItem(key, value);
+
+const loginFormSubmit = async (url, jsonData) => {
+	try {
+		const response = await fetch(url, {
+			method: "POST",
+			headers: {
+				accept: "*/*",
+				"Content-Type": "application/json",
+			},
+			body: jsonData,
+		});
+		if (response.ok) {
+			const responseJson = await response.json();
+			const { accessToken, refreshToken } = responseJson.data;
+			saveToken("accessToken", accessToken);
+			saveToken("refreshToken", refreshToken);
+			authForm.submit();
+		} else {
+			const targetInput = [
+				[emailInput, USER_EMAIL],
+				[passwordInput, USER_PASSWORD],
+			];
+			targetInput.forEach(([input, errorObj]) => {
+				const pTag = findElementFromCloestFormField(input, ".form__warning-message");
+				const errorMessage = errorObj.errorMsg.check;
+
+				updateInputDomError(input, pTag, errorMessage, ERROR_ELEMENT_CLASS);
+			});
+		}
+	} catch (error) {
+		console.log(`에러: ${error.message}`);
+	}
+};
+
+const authForm = document.querySelector(".auth__form");
+
+const formInputs = document.querySelectorAll(".form__input");
+
+const submitButton = document.querySelector("#submit-button");
+
+const eyeIcons = document.querySelectorAll(".form__eye-icon");
+
+const emailInput = document.querySelector("#user-email");
+
+const passwordInput = document.querySelector("#user-password");
+
+emailInput.addEventListener("blur", (e) => {
+	const isValidEmail = makeIsValid(USER_EMAIL.regex);
+	const validators = [isEmptyInput, isValidEmail];
+	VALID_STATUS[e.target.id] = handleInputError(e.target, validators, USER_EMAIL.errorMsg, ERROR_ELEMENT_CLASS);
+});
+
+passwordInput.addEventListener("blur", (e) => {
+	const isValidPassword = makeIsValid(USER_PASSWORD.regex);
+	const validators = [isEmptyInput, isValidPassword];
+
+	VALID_STATUS[e.target.id] = handleInputError(e.target, validators, USER_PASSWORD.errorMsg, ERROR_ELEMENT_CLASS);
+});
+
+eyeIcons.forEach((icon) => {
+	icon.addEventListener("click", (e) => {
+		const imgElement = e.target;
+		const { currentViewMode, passwordInputId } = imgElement.dataset;
+		const inputElement = document.getElementById(passwordInputId);
+		togglePasswordInput(imgElement, inputElement, PASSWORD_VIEW_MODE[currentViewMode]);
+	});
+});
+
+formInputs.forEach((input) => input.addEventListener("keydown", handleAuthEvent));
+
+submitButton.addEventListener("click", handleAuthEvent);

--- a/user/signin.html
+++ b/user/signin.html
@@ -24,16 +24,18 @@
             <div class="form__field">
                 <label for="user-email" class="form__label">이메일</label>
                 <div class="form__field-inner">
-                    <input type="email" name="email" id="user-email" class="form__input" autocomplete="username">
+                    <input type="email" name="email" id="user-email" class="form__input" autocomplete="username" data-error-class="input">
                 </div>
+                <p class="form__warning-message" data-error-class="msg"></p>
+
             </div>
             <div class="form__field">
                 <label for="user-password" class="form__label">비밀번호</label>
                 <div class="form__field-inner">
-                    <input type="password" name="password" id="user-password" class="form__input form__input--password" maxlength="20" autocomplete="current-password">
-                    <img src="../images/eye-off.svg" class="form__eye-icon" data-current-view-mode="off" data-password-input-id="user-password" alt="비밀번호 보기">
+                    <input type="password" name="password" id="user-password" class="form__input form__input--password" maxlength="20" autocomplete="current-password" data-error-class="input">
+                    <img src="../images/eye-off.svg" class="form__eye-icon" data-current-view-mode="off" data-password-input-id="user-password" alt="비밀번호 보기" data-error-class="img">
                 </div>
-
+                <p class="form__warning-message" data-error-class="msg"></p>
             </div>
         </form>
 
@@ -49,7 +51,7 @@
         </footer>
 
     </div>
-    <script type="module" src="./login.js"></script>
+    <script src="./auth.js"></script>
 </body>
 
 </html>

--- a/user/signin.html
+++ b/user/signin.html
@@ -51,7 +51,7 @@
         </footer>
 
     </div>
-    <script src="./auth.js"></script>
+    <script type="module" src="./login.js"></script>
 </body>
 
 </html>

--- a/user/signup.html
+++ b/user/signup.html
@@ -26,6 +26,7 @@
                 <div class="form__field-inner">
                     <input type="email" name="email" id="user-email" class="form__input" autocomplete="username">
                 </div>
+                <p class="form__warning-message" data-error-class="msg"></p>
             </div>
             <div class="form__field">
                 <label for="user-password" class="form__label">비밀번호</label>
@@ -33,6 +34,8 @@
                     <input type="password" name="password" id="user-password" class="form__input form__input--password" autocomplete="new-password">
                     <img src="../images/eye-off.svg" class="form__eye-icon" data-current-view-mode="off" data-password-input-id="user-password" alt="비밀번호 보기">
                 </div>
+                <p class="form__warning-message" data-error-class="msg"></p>
+
             </div>
 
             <div class="form__field form__field--password-check">
@@ -41,6 +44,8 @@
                     <input type="password" name="password-check" id="user-password-check" class="form__input form__input--password" autocomplete="new-password">
                     <img src="../images/eye-off.svg" class="form__eye-icon" data-current-view-mode="off" data-password-input-id="user-password-check" alt="비밀번호 보기">
                 </div>
+                <p class="form__warning-message" data-error-class="msg"></p>
+
             </div>
 
         </form>
@@ -58,7 +63,7 @@
             </div>
         </footer>
     </div>
-    <script type="module" src="./join.js"></script>
+    <script src="./auth.js"></script>
 
 </body>
 

--- a/user/signup.html
+++ b/user/signup.html
@@ -63,7 +63,7 @@
             </div>
         </footer>
     </div>
-    <script src="./auth.js"></script>
+    <script type="module" src="./join.js"></script>
 
 </body>
 


### PR DESCRIPTION
## 요구사항

https://a1b2c3d4zzzzzz.netlify.app/user/signin

### 기본

-   [x] [로그인 페이지] https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “test@codeit.com”, “password”: “sprint101” } POST 요청해서 성공 응답을 받고 “/folder”로 이동하나요?

-   [x] [회원가입 페이지] 이메일 input에서 “test@codeit.com”으로 “/api/check-email” 이메일 중복 확인 POST 요청하면 이메일 중복 에러를 확인할 수 있나요?

-   [x] [회원가입 페이지] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?

### 심화

-   [x] [심화] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?

-   [x] [심화] 로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 “/folder” 페이지로 이동하나요?

## 주요 변경사항

`코드리뷰 피드백 반영` 
- 함수형 프로그래밍으로 코드를 리팩토링을 진행하였습니다.
- 코드의 가독성을 개선했습니다.

`위클리 미션` 
- api로 로그인/회원가입 하는 기능을 추가했습니다. 
- 로컬 스토리지에 accesstoken을 저장하는 엑세스 토큰을 저장하고, 엑세스 토큰이 있다면 바로 folder 페이지로 이동하도록 하였습니다.

## 스크린샷
![스크린샷 2023-10-15 오후 6 41 16](https://github.com/codeit-bootcamp-frontend/1-Weekly-Mission/assets/83692053/cb99ba2b-572c-4225-b2e3-e96b8333ab70)

![스크린샷 2023-10-15 오후 6 41 48](https://github.com/codeit-bootcamp-frontend/1-Weekly-Mission/assets/83692053/94af46b8-1361-48fc-97d7-2e101ba0b08e)


## 멘토에게

- PR 늦게 올려서 죄송합니다 ㅜㅜ 깃헙 푸쉬가 안되서 당황했습니다...

- 비밀번호 인풋을 수정하고 focusout을 하면 비밀번호 체크에 에러효과가 나오도록 하는 요구사항이 있었습니다.
  auth.js 파일에 있는 handleInputError 함수와 handlePasswordNotEqualError 함수가 기능이 거의 같은데,
  타겟을 어떻게 변경시켜야할 지 모르겠어서 진짜 고민 많이했는데 결국은 그냥 이름을 다르게 짓고 인자만 조금 바꿨습니다 ㅜㅜ 
  어떻게 변경하는게 좋았을까요?

- 함수형 프로그래밍에 대해서 검색하다보니까 pipe 함수랑 curry 함수 같은걸 직접 만들어서 구현하기도 하던데 너무 어려워보였습니다... ㅜㅜ 
  현업에서 실제로 그렇게 작업을 많이 하시는지 궁금합니다

- 6주동안 정말 감사했습니다 건강하세요!!

