### PR TITLE
[김선혜] week6

### DIFF
--- a/utils/api.js
+++ b/utils/api.js
@@ -25,4 +25,26 @@ async function signIn(userData) {
 	}
 }
 
-export { signIn };
+async function getIsNewEmail(email) {
+	try {
+		const response = await fetch(`${BASE_URL}/check-email`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ email }),
+		});
+
+		if (!response.ok) {
+			// Q1. 필요한가
+			throw new Error(response.status);
+		} else {
+			return true;
+		}
+	} catch (error) {
+		console.error(error);
+		return false;
+	}
+}
+
+export { signIn, getIsNewEmail };

--- a/utils/api.js
+++ b/utils/api.js
@@ -1,14 +1,14 @@
 import { BASE_URL } from "./constants.js";
 import { goToFolderPage } from "./auth.js";
 
-async function signIn(userData) {
+async function signIn({ email, password }) {
 	try {
 		const response = await fetch(`${BASE_URL}/sign-in`, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
 			},
-			body: JSON.stringify(userData),
+			body: JSON.stringify({ email, password }),
 		});
 
 		if (!response.ok) {
@@ -16,7 +16,7 @@ async function signIn(userData) {
 			throw new Error(response.status);
 		} else {
 			const result = await response.json();
-			const accessToken = result.data.accessToken || "token";
+			const accessToken = result.data.accessToken;
 			window.localStorage.setItem("accessToken", accessToken);
 			goToFolderPage();
 		}
@@ -47,4 +47,28 @@ async function getIsNewEmail(email) {
 	}
 }
 
-export { signIn, getIsNewEmail };
+async function signUp({ email, password }) {
+	try {
+		const response = await fetch(`${BASE_URL}/sign-up`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ email, password }),
+		});
+
+		if (!response.ok) {
+			// Q1. 필요한가
+			throw new Error(response.status);
+		} else {
+			const result = await response.json();
+			const accessToken = result.data.accessToken;
+			window.localStorage.setItem("accessToken", accessToken);
+			goToFolderPage();
+		}
+	} catch (error) {
+		console.error("회원가입 실패: ", error);
+	}
+}
+
+export { signIn, getIsNewEmail, signUp };

--- a/utils/api.js
+++ b/utils/api.js
@@ -12,6 +12,7 @@ async function signIn(userData) {
 		});
 
 		if (!response.ok) {
+			// Q1. 필요한가
 			throw new Error(response.status);
 		} else {
 			const result = await response.json();

--- a/utils/api.js
+++ b/utils/api.js
@@ -1,0 +1,27 @@
+import { BASE_URL } from "./constants.js";
+import { goToFolderPage } from "./auth.js";
+
+async function signIn(userData) {
+	try {
+		const response = await fetch(`${BASE_URL}/sign-in`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(userData),
+		});
+
+		if (!response.ok) {
+			throw new Error(response.status);
+		} else {
+			const result = await response.json();
+			const accessToken = result.data.accessToken || "token";
+			window.localStorage.setItem("accessToken", accessToken);
+			goToFolderPage();
+		}
+	} catch (error) {
+		console.error("로그인 실패:", error);
+	}
+}
+
+export { signIn };

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -7,4 +7,9 @@ function getPasswordVisibility(inputType) {
 		: PASSWORD_TOGGLE_CONSTANT.invisible;
 }
 
-export { getPasswordVisibility };
+// 로그인, 회원가입
+function goToFolderPage() {
+	location.href = FOLDER_PAGE_PATH;
+}
+
+export { getPasswordVisibility, goToFolderPage };

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -1,4 +1,10 @@
-import { PASSWORD_TOGGLE_CONSTANT } from "/utils/constants.js";
+import {
+	USERS,
+	EMAIL_PATTERN,
+	PASSWORD_PATTERN,
+	PASSWORD_TOGGLE_CONSTANT,
+	FOLDER_PAGE_PATH,
+} from "/utils/constants.js";
 
 // 비밀번호 토글
 function getPasswordVisibility(inputType) {
@@ -12,4 +18,82 @@ function goToFolderPage() {
 	location.href = FOLDER_PAGE_PATH;
 }
 
-export { getPasswordVisibility, goToFolderPage };
+function getIsFilledEmail(email) {
+	if (email !== "") {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+function getIsValidEmail(email) {
+	if (EMAIL_PATTERN.test(email)) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+function getIsExistEmail(email) {
+	if (email === USERS[0].email) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+function getIsFilledPassword(password) {
+	if (password !== "") {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+function getIsValidPassword(password) {
+	if (PASSWORD_PATTERN.test(password)) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+function getIsCorrectPassword(password) {
+	if (password === USERS[0].password) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+function getIsFilledConfirmPassword(confirmPassword) {
+	if (confirmPassword !== "") {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+function getIsConfirmedConfirmPassword(
+	confirmPassword,
+	passwordInputElementValue
+) {
+	if (confirmPassword === passwordInputElementValue) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+export {
+	getPasswordVisibility,
+	goToFolderPage,
+	getIsFilledEmail,
+	getIsValidEmail,
+	getIsExistEmail,
+	getIsFilledPassword,
+	getIsValidPassword,
+	getIsCorrectPassword,
+	getIsFilledConfirmPassword,
+	getIsConfirmedConfirmPassword,
+};

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -34,14 +34,6 @@ function getIsValidEmail(email) {
 	}
 }
 
-function getIsExistEmail(email) {
-	if (email === USERS[0].email) {
-		return true;
-	} else {
-		return false;
-	}
-}
-
 function getIsFilledPassword(password) {
 	if (password !== "") {
 		return true;
@@ -90,7 +82,6 @@ export {
 	goToFolderPage,
 	getIsFilledEmail,
 	getIsValidEmail,
-	getIsExistEmail,
 	getIsFilledPassword,
 	getIsValidPassword,
 	getIsCorrectPassword,

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -1,76 +1,10 @@
-/* 비밀번호 토글 */
-// 상수
-const PASSWORD_TOGGLE_CONSTANT = {
-	visible: {
-		inputType: "text",
-		imageSrc: "/public/icons/password-visible.svg",
-		imageAlt: "비밀번호 보이기 아이콘",
-	},
-	invisible: {
-		inputType: "password",
-		imageSrc: "/public/icons/password-invisible.svg",
-		imageAlt: "비밀번호 숨김 아이콘",
-	},
-};
+import { PASSWORD_TOGGLE_CONSTANT } from "/utils/constants.js";
 
-// DOM 요소
-const passwordToggleElement = document.querySelector(".auth__toggle-password");
-
-// 함수
+// 비밀번호 토글
 function getPasswordVisibility(inputType) {
 	return inputType === "password"
 		? PASSWORD_TOGGLE_CONSTANT.visible
 		: PASSWORD_TOGGLE_CONSTANT.invisible;
 }
 
-/* 유효성 검사 */
-// 상수
-const USERS = [
-	{
-		email: "test@codeit.com",
-		password: "codeit101",
-	},
-];
-
-const AUTH_HINT = {
-	email: {
-		default: "",
-		isNotFilled: "이메일을 입력해주세요.",
-		isNotValidated: "올바른 이메일 주소가 아닙니다.",
-		isNotExists: "이메일을 변경해주세요.",
-		isExists: "이미 사용중인 이메일입니다.",
-	},
-	password: {
-		default: "",
-		isNotFilled: "비밀번호를 입력해주세요.",
-		isNotExists: "비밀번호를 변경해주세요.",
-		isNotValidated: "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.",
-		isNotConfirmed: "비밀번호가 일치하지 않아요.",
-	},
-};
-
-const EMAIL_PATTERN = /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
-
-const INPUT_STATUS = {
-	default: "default",
-	isNotFilled: "isNotFilled",
-	isNotValidated: "isNotValidated",
-	isExists: "isExists",
-	isNotExists: "isNotExists",
-	isNotConfirmed: "isNotConfirmed",
-};
-
-const INPUT_HINT_CLASSNAME = "auth__input--hint";
-
-const FOLDER_PAGE_PATH = "/pages/forder.html";
-
-export {
-	passwordToggleElement,
-	getPasswordVisibility,
-	USERS,
-	AUTH_HINT,
-	EMAIL_PATTERN,
-	INPUT_STATUS,
-	INPUT_HINT_CLASSNAME,
-	FOLDER_PAGE_PATH,
-};
+export { getPasswordVisibility };

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -31,7 +31,7 @@ const AUTH_HINT = {
 	password: {
 		default: "",
 		isNotFilled: "비밀번호를 입력해주세요.",
-		isNotExists: "비밀번호를 변경해주세요.",
+		isNotCorrect: "비밀번호를 변경해주세요.",
 		isNotValidated: "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.",
 		isNotConfirmed: "비밀번호가 일치하지 않아요.",
 	},
@@ -48,6 +48,7 @@ const INPUT_STATUS = {
 	isExists: "isExists",
 	isNotExists: "isNotExists",
 	isNotConfirmed: "isNotConfirmed",
+	isNotCorrect: "isNotCorrect",
 };
 
 const INPUT_HINT_CLASSNAME = "auth__input--hint";

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,0 +1,66 @@
+// 로그인, 회원가입 폼 비밀번호 토글
+const PASSWORD_TOGGLE_CONSTANT = {
+	visible: {
+		inputType: "text",
+		imageSrc: "/public/icons/password-visible.svg",
+		imageAlt: "비밀번호 보이기 아이콘",
+	},
+	invisible: {
+		inputType: "password",
+		imageSrc: "/public/icons/password-invisible.svg",
+		imageAlt: "비밀번호 숨김 아이콘",
+	},
+};
+
+// 로그인, 회원가입
+const USERS = [
+	{
+		email: "test@codeit.com",
+		password: "codeit101",
+	},
+];
+
+const AUTH_HINT = {
+	email: {
+		default: "",
+		isNotFilled: "이메일을 입력해주세요.",
+		isNotValidated: "올바른 이메일 주소가 아닙니다.",
+		isNotExists: "이메일을 변경해주세요.",
+		isExists: "이미 사용중인 이메일입니다.",
+	},
+	password: {
+		default: "",
+		isNotFilled: "비밀번호를 입력해주세요.",
+		isNotExists: "비밀번호를 변경해주세요.",
+		isNotValidated: "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.",
+		isNotConfirmed: "비밀번호가 일치하지 않아요.",
+	},
+};
+
+const EMAIL_PATTERN = /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
+
+const PASSWORD_PATTERN = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/;
+
+const INPUT_STATUS = {
+	default: "default",
+	isNotFilled: "isNotFilled",
+	isNotValidated: "isNotValidated",
+	isExists: "isExists",
+	isNotExists: "isNotExists",
+	isNotConfirmed: "isNotConfirmed",
+};
+
+const INPUT_HINT_CLASSNAME = "auth__input--hint";
+
+const FOLDER_PAGE_PATH = "/pages/forder.html";
+
+export {
+	PASSWORD_TOGGLE_CONSTANT,
+	USERS,
+	AUTH_HINT,
+	EMAIL_PATTERN,
+	PASSWORD_PATTERN,
+	INPUT_STATUS,
+	INPUT_HINT_CLASSNAME,
+	FOLDER_PAGE_PATH,
+};

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -55,6 +55,8 @@ const INPUT_HINT_CLASSNAME = "auth__input--hint";
 
 const FOLDER_PAGE_PATH = "/pages/forder.html";
 
+const BASE_URL = "https://bootcamp-api.codeit.kr/api";
+
 export {
 	PASSWORD_TOGGLE_CONSTANT,
 	USERS,
@@ -64,4 +66,5 @@ export {
 	INPUT_STATUS,
 	INPUT_HINT_CLASSNAME,
 	FOLDER_PAGE_PATH,
+	BASE_URL,
 };

--- a/utils/signin.js
+++ b/utils/signin.js
@@ -1,5 +1,4 @@
 import {
-	goToFolderPage,
 	getPasswordVisibility,
 	getIsFilledEmail,
 	getIsValidEmail,
@@ -13,6 +12,8 @@ import {
 	INPUT_STATUS,
 	INPUT_HINT_CLASSNAME,
 } from "/utils/constants.js";
+
+import { signIn } from "./api.js";
 
 /* 비밀번호 토글 */
 const passwordToggleElement = document.querySelector(".auth__toggle-password");
@@ -75,15 +76,12 @@ function checkPasswordFocusout(password) {
 	}
 }
 
-function getIsUserEmail(email) {
+function getIsCompleteEmail(email) {
 	if (!getIsFilledEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isNotFilled);
 		return false;
 	} else if (!getIsValidEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isNotValidated);
-		return false;
-	} else if (!getIsExistEmail(email)) {
-		changeEmailHint(INPUT_STATUS.isNotExists);
 		return false;
 	} else {
 		changeEmailHint(INPUT_STATUS.default);
@@ -91,12 +89,9 @@ function getIsUserEmail(email) {
 	}
 }
 
-function getIsUserPassword(password) {
+function getIsCompletePassword(password) {
 	if (!getIsFilledPassword(password)) {
 		changePasswordHint(INPUT_STATUS.isNotFilled);
-		return false;
-	} else if (!getIsCorrectPassword(password)) {
-		changePasswordHint(INPUT_STATUS.isNotCorrect);
 		return false;
 	} else {
 		changePasswordHint(INPUT_STATUS.default);
@@ -105,14 +100,9 @@ function getIsUserPassword(password) {
 }
 
 function clickSignin(email, password) {
-	const isUserEmail = getIsUserEmail(email);
-	if (!isUserEmail) {
-		// TODO 유저 이메일이 아닌경우 비밀번호 입력 여부만 검사하고 리턴
-		checkPasswordFocusout(password);
-		return;
-	}
-	const isUserPassword = getIsUserPassword(password);
-	if (isUserEmail && isUserPassword) goToFolderPage();
+	const isCompleteEmail = getIsCompleteEmail(email);
+	const isCompletePassword = getIsCompletePassword(password);
+	if (isCompleteEmail && isCompletePassword) signIn({ email, password });
 }
 
 emailInputElement.addEventListener("focusout", (e) => {

--- a/utils/signin.js
+++ b/utils/signin.js
@@ -1,4 +1,4 @@
-import { getPasswordVisibility } from "/utils/auth.js";
+import { goToFolderPage, getPasswordVisibility } from "/utils/auth.js";
 import {
 	USERS,
 	AUTH_HINT,
@@ -98,7 +98,7 @@ function getIsUserPassword(password) {
 	}
 }
 
-function signinSuccess() {
+function goToFolderPage() {
 	location.href = FOLDER_PAGE_PATH;
 }
 
@@ -110,7 +110,7 @@ function clickSignin(email, password) {
 		return;
 	}
 	const isUserPassword = getIsUserPassword(password);
-	if (isUserEmail && isUserPassword) signinSuccess();
+	if (isUserEmail && isUserPassword) goToFolderPage();
 }
 
 // 이벤트 핸들러 등록

--- a/utils/signin.js
+++ b/utils/signin.js
@@ -1,16 +1,16 @@
+import { getPasswordVisibility } from "/utils/auth.js";
 import {
-	passwordToggleElement,
-	getPasswordVisibility,
 	USERS,
 	AUTH_HINT,
 	EMAIL_PATTERN,
 	INPUT_STATUS,
 	INPUT_HINT_CLASSNAME,
 	FOLDER_PAGE_PATH,
-} from "/utils/auth.js";
+} from "/utils/constants.js";
 
 /* 비밀번호 토글 */
-// 이벤트 핸들러
+const passwordToggleElement = document.querySelector(".auth__toggle-password");
+
 passwordToggleElement.addEventListener("click", () => {
 	const passwordInput = document.querySelector(".auth__input-password");
 	const passwordIcon = document.querySelector(".auth__icon-password");
@@ -23,14 +23,12 @@ passwordToggleElement.addEventListener("click", () => {
 });
 
 /* 유효성 검사 */
-// DOM 요소
 const emailInputElement = document.querySelector(".auth__input-email");
 const passwordInputElement = document.querySelector(".auth__input-password");
 const emailHintElement = document.querySelector(".auth__email-hint");
 const passwordHintElement = document.querySelector(".auth__password-hint");
 const signinButtonElement = document.querySelector(".signin__button");
 
-// 함수
 function changeEmailHint(hintType) {
 	if (emailHintElement.innerText === AUTH_HINT.email[hintType]) return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
 	emailHintElement.innerText = AUTH_HINT.email[hintType];
@@ -53,7 +51,6 @@ function changePasswordHint(hintType) {
 	}
 }
 
-// 함수
 function checkEmailFocusout(email) {
 	if (email === "") {
 		changeEmailHint(INPUT_STATUS.isNotFilled);

--- a/utils/signin.js
+++ b/utils/signin.js
@@ -90,7 +90,7 @@ function getIsUserPassword(password) {
 		changePasswordHint(INPUT_STATUS.isNotFilled);
 		return false;
 	} else if (password !== USERS[0].password) {
-		changePasswordHint(INPUT_STATUS.isNotExists);
+		changePasswordHint(INPUT_STATUS.isNotCorrect);
 		return false;
 	} else {
 		changePasswordHint(INPUT_STATUS.default);

--- a/utils/signin.js
+++ b/utils/signin.js
@@ -1,11 +1,17 @@
-import { goToFolderPage, getPasswordVisibility } from "/utils/auth.js";
 import {
-	USERS,
+	goToFolderPage,
+	getPasswordVisibility,
+	getIsFilledEmail,
+	getIsValidEmail,
+	getIsExistEmail,
+	getIsFilledPassword,
+	getIsCorrectPassword,
+} from "/utils/auth.js";
+
+import {
 	AUTH_HINT,
-	EMAIL_PATTERN,
 	INPUT_STATUS,
 	INPUT_HINT_CLASSNAME,
-	FOLDER_PAGE_PATH,
 } from "/utils/constants.js";
 
 /* 비밀번호 토글 */
@@ -52,9 +58,9 @@ function changePasswordHint(hintType) {
 }
 
 function checkEmailFocusout(email) {
-	if (email === "") {
+	if (!getIsFilledEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isNotFilled);
-	} else if (!EMAIL_PATTERN.test(email)) {
+	} else if (!getIsValidEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isNotValidated);
 	} else {
 		changeEmailHint(INPUT_STATUS.default);
@@ -70,13 +76,13 @@ function checkPasswordFocusout(password) {
 }
 
 function getIsUserEmail(email) {
-	if (email === "") {
+	if (!getIsFilledEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isNotFilled);
 		return false;
-	} else if (!EMAIL_PATTERN.test(email)) {
+	} else if (!getIsValidEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isNotValidated);
 		return false;
-	} else if (email !== USERS[0].email) {
+	} else if (!getIsExistEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isNotExists);
 		return false;
 	} else {
@@ -86,20 +92,16 @@ function getIsUserEmail(email) {
 }
 
 function getIsUserPassword(password) {
-	if (password === "") {
+	if (!getIsFilledPassword(password)) {
 		changePasswordHint(INPUT_STATUS.isNotFilled);
 		return false;
-	} else if (password !== USERS[0].password) {
+	} else if (!getIsCorrectPassword(password)) {
 		changePasswordHint(INPUT_STATUS.isNotCorrect);
 		return false;
 	} else {
 		changePasswordHint(INPUT_STATUS.default);
 		return true;
 	}
-}
-
-function goToFolderPage() {
-	location.href = FOLDER_PAGE_PATH;
 }
 
 function clickSignin(email, password) {
@@ -113,7 +115,6 @@ function clickSignin(email, password) {
 	if (isUserEmail && isUserPassword) goToFolderPage();
 }
 
-// 이벤트 핸들러 등록
 emailInputElement.addEventListener("focusout", (e) => {
 	checkEmailFocusout(e.target.value);
 });

--- a/utils/signin.js
+++ b/utils/signin.js
@@ -2,9 +2,7 @@ import {
 	getPasswordVisibility,
 	getIsFilledEmail,
 	getIsValidEmail,
-	getIsExistEmail,
 	getIsFilledPassword,
-	getIsCorrectPassword,
 } from "/utils/auth.js";
 
 import {
@@ -99,10 +97,9 @@ function getIsCompletePassword(password) {
 	}
 }
 
-function clickSignin(email, password) {
-	const isCompleteEmail = getIsCompleteEmail(email);
-	const isCompletePassword = getIsCompletePassword(password);
-	if (isCompleteEmail && isCompletePassword) signIn({ email, password });
+async function clickSignin(email, password) {
+	if (getIsCompleteEmail(email) && getIsCompletePassword(password))
+		await signIn({ email, password });
 }
 
 emailInputElement.addEventListener("focusout", (e) => {

--- a/utils/signin.js
+++ b/utils/signin.js
@@ -1,4 +1,5 @@
 import {
+	goToFolderPage,
 	getPasswordVisibility,
 	getIsFilledEmail,
 	getIsValidEmail,
@@ -12,6 +13,15 @@ import {
 } from "/utils/constants.js";
 
 import { signIn } from "./api.js";
+
+/* 로그인 상태로 접근 시 리다이렉트 */
+(function () {
+	const accessToken = localStorage.getItem("accessToken");
+
+	if (accessToken) {
+		goToFolderPage();
+	}
+})();
 
 /* 비밀번호 토글 */
 const passwordToggleElement = document.querySelector(".auth__toggle-password");

--- a/utils/signin.js
+++ b/utils/signin.js
@@ -104,7 +104,11 @@ function signinSuccess() {
 
 function clickSignin(email, password) {
 	const isUserEmail = getIsUserEmail(email);
-	if (!isUserEmail) return checkPasswordFocusout(password); // TODO 유저 이메일이 아닌경우 비밀번호 입력 여부만 검사하고 리턴
+	if (!isUserEmail) {
+		// TODO 유저 이메일이 아닌경우 비밀번호 입력 여부만 검사하고 리턴
+		checkPasswordFocusout(password);
+		return;
+	}
 	const isUserPassword = getIsUserPassword(password);
 	if (isUserEmail && isUserPassword) signinSuccess();
 }

--- a/utils/signup.js
+++ b/utils/signup.js
@@ -159,7 +159,7 @@ function getIsConfirmedPassword(passwordConfirm) {
 	}
 }
 
-function clickSignup(email, password, passwordConfirm) {
+function clickSignup({ email, password, passwordConfirm }) {
 	const isValidatedEmail = getIsValidatedEmail(email);
 	const isValidatedPassword = getIsValidatedPassword(password);
 	const isConfirmedPassword = getIsConfirmedPassword(passwordConfirm);
@@ -190,9 +190,9 @@ passwordInputElement.addEventListener("focusout", (e) => {
 
 signupButtonElement.addEventListener("click", (e) => {
 	e.preventDefault();
-	clickSignup(
-		emailInputElement.value,
-		passwordInputElement.value,
-		passwordConfirmInputElement.value
-	);
+	clickSignup({
+		email: emailInputElement.value,
+		password: passwordInputElement.value,
+		passwordConfirm: passwordConfirmInputElement.value,
+	});
 });

--- a/utils/signup.js
+++ b/utils/signup.js
@@ -19,6 +19,15 @@ import { signUp } from "./api.js";
 
 import { getIsNewEmail } from "/utils/api.js";
 
+/* 로그인 상태로 접근 시 리다이렉트 */
+(function () {
+	const accessToken = localStorage.getItem("accessToken");
+
+	if (accessToken) {
+		goToFolderPage();
+	}
+})();
+
 /* 비밀번호 토글 */
 const confirmPasswordToggleElement = document.querySelector(
 	".auth__toggle-password--confirm"

--- a/utils/signup.js
+++ b/utils/signup.js
@@ -114,7 +114,6 @@ function checkPasswordFocusout(password) {
 }
 
 function checkPasswordConfirmFocusout(passwordConfirm) {
-	console.log(passwordConfirm, passwordInputElement.value);
 	if (passwordConfirm === "") {
 		changePasswordConfirmHint(INPUT_STATUS.isNotFilled);
 	} else if (passwordConfirm !== passwordInputElement.value) {
@@ -154,7 +153,6 @@ function getIsValidatedPassword(password) {
 }
 
 function getIsConfirmedPassword(passwordConfirm) {
-	console.log(passwordConfirm, passwordInputElement.value);
 	if (passwordConfirm === "") {
 		changePasswordConfirmHint(INPUT_STATUS.isNotFilled);
 		return false;

--- a/utils/signup.js
+++ b/utils/signup.js
@@ -1,21 +1,29 @@
-import { goToFolderPage, getPasswordVisibility } from "/utils/auth.js";
 import {
-	USERS,
+	goToFolderPage,
+	getPasswordVisibility,
+	getIsFilledEmail,
+	getIsValidEmail,
+	getIsExistEmail,
+	getIsFilledPassword,
+	getIsValidPassword,
+	getIsFilledConfirmPassword,
+	getIsConfirmedConfirmPassword,
+} from "/utils/auth.js";
+
+import {
 	AUTH_HINT,
-	EMAIL_PATTERN,
-	PASSWORD_PATTERN,
 	INPUT_STATUS,
 	INPUT_HINT_CLASSNAME,
 } from "/utils/constants.js";
 
 /* 비밀번호 토글 */
-const passwordConfirmToggleElement = document.querySelector(
+const confirmPasswordToggleElement = document.querySelector(
 	".auth__toggle-password--confirm"
 );
-const passwordConfirmInputElement = document.querySelector(
+const confirmPasswordInputElement = document.querySelector(
 	".auth__input-password--confirm"
 );
-const passwordConfirmIconElement = document.querySelector(
+const confirmPasswordIconElement = document.querySelector(
 	".auth__icon-password--confirm"
 );
 const passwordToggleElement = document.querySelector(".auth__toggle-password");
@@ -31,28 +39,26 @@ passwordToggleElement.addEventListener("click", () => {
 	passwordIcon.alt = passwordVisibility.imageAlt;
 });
 
-passwordConfirmToggleElement.addEventListener("click", () => {
+confirmPasswordToggleElement.addEventListener("click", () => {
 	const passwordVisibility = getPasswordVisibility(
-		passwordConfirmInputElement.type
+		confirmPasswordInputElement.type
 	);
 
-	passwordConfirmInputElement.type = passwordVisibility.inputType;
-	passwordConfirmIconElement.src = passwordVisibility.imageSrc;
-	passwordConfirmIconElement.alt = passwordVisibility.imageAlt;
+	confirmPasswordInputElement.type = passwordVisibility.inputType;
+	confirmPasswordIconElement.src = passwordVisibility.imageSrc;
+	confirmPasswordIconElement.alt = passwordVisibility.imageAlt;
 });
 
 /* 유효성 검사 */
-// DOM 요소
 const emailInputElement = document.querySelector(".auth__input-email");
 const passwordInputElement = document.querySelector(".auth__input-password");
 const emailHintElement = document.querySelector(".auth__email-hint");
 const passwordHintElement = document.querySelector(".auth__password-hint");
-const passwordConfirmHintElement = document.querySelector(
+const confirmPasswordHintElement = document.querySelector(
 	".auth__password-hint--confirm"
 );
 const signupButtonElement = document.querySelector(".signup__button");
 
-// 함수
 function changeEmailHint(hintType) {
 	if (emailHintElement.innerText === AUTH_HINT.email[hintType]) return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
 	emailHintElement.innerText = AUTH_HINT.email[hintType];
@@ -76,22 +82,23 @@ function changePasswordHint(hintType) {
 }
 
 function changePasswordConfirmHint(hintType) {
-	if (passwordConfirmHintElement.innerText === AUTH_HINT.password[hintType])
+	if (confirmPasswordHintElement.innerText === AUTH_HINT.password[hintType])
 		return; // 이전 상태와 바꾸려는 상태가 동일할 경우 리턴
-	passwordConfirmHintElement.innerText = AUTH_HINT.password[hintType];
+	confirmPasswordHintElement.innerText = AUTH_HINT.password[hintType];
 
 	if (hintType === INPUT_STATUS.default) {
-		passwordConfirmInputElement.classList.remove(INPUT_HINT_CLASSNAME);
+		confirmPasswordInputElement.classList.remove(INPUT_HINT_CLASSNAME);
 	} else {
-		passwordConfirmInputElement.classList.add(INPUT_HINT_CLASSNAME);
+		confirmPasswordInputElement.classList.add(INPUT_HINT_CLASSNAME);
 	}
 }
+
 function checkEmailFocusout(email) {
-	if (email === "") {
+	if (!getIsFilledEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isNotFilled);
-	} else if (!EMAIL_PATTERN.test(email)) {
+	} else if (!getIsValidEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isNotValidated);
-	} else if (email === USERS[0].email) {
+	} else if (getIsExistEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isExists);
 	} else {
 		changeEmailHint(INPUT_STATUS.default);
@@ -99,33 +106,35 @@ function checkEmailFocusout(email) {
 }
 
 function checkPasswordFocusout(password) {
-	if (password === "") {
+	if (!getIsFilledPassword(password)) {
 		changePasswordHint(INPUT_STATUS.isNotFilled);
-	} else if (!PASSWORD_PATTERN.test(password)) {
+	} else if (!getIsValidPassword(password)) {
 		changePasswordHint(INPUT_STATUS.isNotValidated);
 	} else {
 		changePasswordHint(INPUT_STATUS.default);
 	}
 }
 
-function checkPasswordConfirmFocusout(passwordConfirm) {
-	if (passwordConfirm === "") {
+function checkPasswordConfirmFocusout(confirmPassword) {
+	if (!getIsFilledConfirmPassword(confirmPassword)) {
 		changePasswordConfirmHint(INPUT_STATUS.isNotFilled);
-	} else if (passwordConfirm !== passwordInputElement.value) {
+	} else if (
+		!getIsConfirmedConfirmPassword(confirmPassword, passwordInputElement.value)
+	) {
 		changePasswordConfirmHint(INPUT_STATUS.isNotConfirmed);
 	} else {
 		changePasswordConfirmHint(INPUT_STATUS.default);
 	}
 }
 
-function getIsValidatedEmail(email) {
-	if (email === "") {
+function getIsCompleteEmail(email) {
+	if (!getIsFilledEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isNotFilled);
 		return false;
-	} else if (!EMAIL_PATTERN.test(email)) {
+	} else if (!getIsValidEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isNotValidated);
 		return false;
-	} else if (email === USERS[0].email) {
+	} else if (getIsExistEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isExists);
 		return false;
 	} else {
@@ -134,11 +143,11 @@ function getIsValidatedEmail(email) {
 	}
 }
 
-function getIsValidatedPassword(password) {
-	if (password === "") {
+function getIsCompletePassword(password) {
+	if (!getIsFilledPassword(password)) {
 		changePasswordHint(INPUT_STATUS.isNotFilled);
 		return false;
-	} else if (!PASSWORD_PATTERN.test(password)) {
+	} else if (!getIsValidPassword(password)) {
 		changePasswordHint(INPUT_STATUS.isNotValidated);
 		return false;
 	} else {
@@ -147,11 +156,13 @@ function getIsValidatedPassword(password) {
 	}
 }
 
-function getIsConfirmedPassword(passwordConfirm) {
-	if (passwordConfirm === "") {
+function getIsConfirmedPassword(confirmPassword) {
+	if (!getIsFilledConfirmPassword(confirmPassword)) {
 		changePasswordConfirmHint(INPUT_STATUS.isNotFilled);
 		return false;
-	} else if (passwordConfirm !== passwordInputElement.value) {
+	} else if (
+		!getIsConfirmedConfirmPassword(confirmPassword, passwordInputElement.value)
+	) {
 		changePasswordConfirmHint(INPUT_STATUS.isNotConfirmed);
 		return false;
 	} else {
@@ -159,12 +170,12 @@ function getIsConfirmedPassword(passwordConfirm) {
 	}
 }
 
-function clickSignup({ email, password, passwordConfirm }) {
-	const isValidatedEmail = getIsValidatedEmail(email);
-	const isValidatedPassword = getIsValidatedPassword(password);
-	const isConfirmedPassword = getIsConfirmedPassword(passwordConfirm);
-
-	if (isValidatedEmail && isValidatedPassword && isConfirmedPassword)
+function clickSignup({ email, password, confirmPassword }) {
+	if (
+		getIsCompleteEmail(email) &&
+		getIsCompletePassword(password) &&
+		getIsConfirmedPassword(confirmPassword)
+	)
 		goToFolderPage();
 }
 
@@ -176,7 +187,7 @@ passwordInputElement.addEventListener("focusout", (e) => {
 	checkPasswordFocusout(e.target.value);
 });
 
-passwordConfirmInputElement.addEventListener("focusout", (e) => {
+confirmPasswordInputElement.addEventListener("focusout", (e) => {
 	checkPasswordConfirmFocusout(e.target.value);
 });
 
@@ -193,6 +204,6 @@ signupButtonElement.addEventListener("click", (e) => {
 	clickSignup({
 		email: emailInputElement.value,
 		password: passwordInputElement.value,
-		passwordConfirm: passwordConfirmInputElement.value,
+		confirmPassword: confirmPasswordInputElement.value,
 	});
 });

--- a/utils/signup.js
+++ b/utils/signup.js
@@ -1,16 +1,15 @@
+import { getPasswordVisibility } from "/utils/auth.js";
 import {
-	passwordToggleElement,
-	getPasswordVisibility,
 	USERS,
 	AUTH_HINT,
 	EMAIL_PATTERN,
+	PASSWORD_PATTERN,
 	INPUT_STATUS,
 	INPUT_HINT_CLASSNAME,
 	FOLDER_PAGE_PATH,
-} from "/utils/auth.js";
+} from "/utils/constants.js";
 
 /* 비밀번호 토글 */
-// DOM 요소
 const passwordConfirmToggleElement = document.querySelector(
 	".auth__toggle-password--confirm"
 );
@@ -20,8 +19,8 @@ const passwordConfirmInputElement = document.querySelector(
 const passwordConfirmIconElement = document.querySelector(
 	".auth__icon-password--confirm"
 );
+const passwordToggleElement = document.querySelector(".auth__toggle-password");
 
-// 핸들러
 passwordToggleElement.addEventListener("click", () => {
 	const passwordInput = document.querySelector(".auth__input-password");
 	const passwordIcon = document.querySelector(".auth__icon-password");
@@ -44,9 +43,6 @@ passwordConfirmToggleElement.addEventListener("click", () => {
 });
 
 /* 유효성 검사 */
-// 상수
-const PASSWORD_PATTERN = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/;
-
 // DOM 요소
 const emailInputElement = document.querySelector(".auth__input-email");
 const passwordInputElement = document.querySelector(".auth__input-password");

--- a/utils/signup.js
+++ b/utils/signup.js
@@ -3,7 +3,6 @@ import {
 	getPasswordVisibility,
 	getIsFilledEmail,
 	getIsValidEmail,
-	getIsExistEmail,
 	getIsFilledPassword,
 	getIsValidPassword,
 	getIsFilledConfirmPassword,
@@ -15,6 +14,8 @@ import {
 	INPUT_STATUS,
 	INPUT_HINT_CLASSNAME,
 } from "/utils/constants.js";
+
+import { getIsNewEmail } from "/utils/api.js";
 
 /* 비밀번호 토글 */
 const confirmPasswordToggleElement = document.querySelector(
@@ -93,12 +94,14 @@ function changePasswordConfirmHint(hintType) {
 	}
 }
 
-function checkEmailFocusout(email) {
+async function checkEmailFocusout(email) {
+	const isNewEmail = await getIsNewEmail(email);
+
 	if (!getIsFilledEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isNotFilled);
 	} else if (!getIsValidEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isNotValidated);
-	} else if (getIsExistEmail(email)) {
+	} else if (!isNewEmail) {
 		changeEmailHint(INPUT_STATUS.isExists);
 	} else {
 		changeEmailHint(INPUT_STATUS.default);
@@ -127,14 +130,16 @@ function checkPasswordConfirmFocusout(confirmPassword) {
 	}
 }
 
-function getIsCompleteEmail(email) {
+async function getIsCompleteEmail(email) {
+	const isNewEmail = await getIsNewEmail(email);
+
 	if (!getIsFilledEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isNotFilled);
 		return false;
 	} else if (!getIsValidEmail(email)) {
 		changeEmailHint(INPUT_STATUS.isNotValidated);
 		return false;
-	} else if (getIsExistEmail(email)) {
+	} else if (!isNewEmail) {
 		changeEmailHint(INPUT_STATUS.isExists);
 		return false;
 	} else {

--- a/utils/signup.js
+++ b/utils/signup.js
@@ -160,7 +160,7 @@ function getIsConfirmedPassword(passwordConfirm) {
 	}
 }
 
-function signupSuccess() {
+function goToFolderPage() {
 	location.href = FOLDER_PAGE_PATH;
 }
 
@@ -170,7 +170,7 @@ function clickSignup(email, password, passwordConfirm) {
 	const isConfirmedPassword = getIsConfirmedPassword(passwordConfirm);
 
 	if (isValidatedEmail && isValidatedPassword && isConfirmedPassword)
-		signupSuccess();
+		goToFolderPage();
 }
 
 emailInputElement.addEventListener("focusout", (e) => {

--- a/utils/signup.js
+++ b/utils/signup.js
@@ -15,6 +15,8 @@ import {
 	INPUT_HINT_CLASSNAME,
 } from "/utils/constants.js";
 
+import { signUp } from "./api.js";
+
 import { getIsNewEmail } from "/utils/api.js";
 
 /* 비밀번호 토글 */
@@ -175,13 +177,13 @@ function getIsConfirmedPassword(confirmPassword) {
 	}
 }
 
-function clickSignup({ email, password, confirmPassword }) {
+async function clickSignup({ email, password, confirmPassword }) {
 	if (
 		getIsCompleteEmail(email) &&
 		getIsCompletePassword(password) &&
 		getIsConfirmedPassword(confirmPassword)
 	)
-		goToFolderPage();
+		await signUp({ email, password });
 }
 
 emailInputElement.addEventListener("focusout", (e) => {

--- a/utils/signup.js
+++ b/utils/signup.js
@@ -1,4 +1,4 @@
-import { getPasswordVisibility } from "/utils/auth.js";
+import { goToFolderPage, getPasswordVisibility } from "/utils/auth.js";
 import {
 	USERS,
 	AUTH_HINT,
@@ -6,7 +6,6 @@ import {
 	PASSWORD_PATTERN,
 	INPUT_STATUS,
 	INPUT_HINT_CLASSNAME,
-	FOLDER_PAGE_PATH,
 } from "/utils/constants.js";
 
 /* 비밀번호 토글 */
@@ -158,10 +157,6 @@ function getIsConfirmedPassword(passwordConfirm) {
 	} else {
 		return true;
 	}
-}
-
-function goToFolderPage() {
-	location.href = FOLDER_PAGE_PATH;
 }
 
 function clickSignup(email, password, passwordConfirm) {


### PR DESCRIPTION
## 요구사항

### 기본
#### 로그인 페이지
- [x] https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “[test@codeit.com](mailto:test@codeit.com)”, “password”: “sprint101” } POST 요청해서 성공 응답을 받고 “/folder”로 이동하나요?
#### 회원가입 페이지
- [x] 이메일 input에서 “[test@codeit.com](mailto:test@codeit.com)”으로 “/api/check-email” 이메일 중복 확인 POST 요청하면 이메일 중복 에러를 확인할 수 있나요?
- [x] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?
심화
### 심화
- [x] 로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 “/folder” 페이지로 이동하나요?


## 주요 변경사항
### 리팩토링
- 콘솔 제거
- 상수만 따로 모듈 분리
- goToFolderPage
- named parameter
- 더 작은 기능으로 함수 분리

## 멘토에게
- [노션 링크](https://narrow-wrist-63f.notion.site/6-_-41288b9e3fb3439583d621fd466db26a?pvs=4)
