### PR TITLE
[민서영] week6

### DIFF
--- a/assets/css/sign_form.css
+++ b/assets/css/sign_form.css
@@ -43,24 +43,21 @@ main{
   width: 100%; 
 }
 
-.signin__label,
-.signup__label{
+.sign__label{
   display: inline-block;
   font-size: 0.875rem;
   font-weight: 400;
   padding-bottom: 0.75rem;
 }
 
-.signin__input__wrap,
-.signup__input__wrap{
+.input__box{
   display:flex;
   align-items: center;
   position: relative;
 }
 
-.signin__pw__wrap,
-.signup__pw__wrap,
-.signup__pw__wrap--confirm{
+.sign__pw__wrap,
+.sign__pw__wrap--confirm{
   margin-top: 1.5rem;
 }
 
@@ -118,8 +115,7 @@ main{
 }
 
 /*--소셜 로그인--*/
-.signin--social,
-.signup--social{
+.sign--social{
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -134,8 +130,7 @@ main{
   font-weight: 400;
 }
 
-.signin--social-icon,
-.signup--social-icon{
+.sign--social-icon{
   display: flex;
   flex-direction: row;
   justify-content: space-around;
@@ -144,8 +139,7 @@ main{
   list-style: none;
 }
 
-.signin--social-icon img,
-.signup--social-icon img{
+.sign--social-icon img{
   vertical-align: bottom;
 }
 

--- a/assets/js/const.js
+++ b/assets/js/const.js
@@ -13,6 +13,34 @@ const inputPw = document.querySelector('.input--pw');
 const pwConfirmWrap = document.querySelector('.sign__pw__wrap--confirm')
 const inputPwConfirm = document.querySelector('.input--pw-confirm')
 
+//Error Message
+/*const incorrectEmailError = "이메일을 확인해주세요."
+const incorrectPwError = "비밀번호를 확인해주세요."
+const emptyEmailError = "이메일을 입력해주세요."
+const invalidEmailError = "올바른 이메일 주소가 아닙니다."
+const emptyPwError = "비밀번호를 입력해주세요."*/
+
+const ERROR = {
+  EMAIL: {
+    incorrect: "이메일을 확인해주세요.", //ERROR.EMAIL.incorrect
+    empty: "이메일을 입력해주세요.", //ERROR.EMAIL.empty
+    invalid: "올바른 이메일 주소가 아닙니다.", //ERROR.EMAIL.invalid
+  },
+  PW: {
+    incorrect: "비밀번호를 확인해주세요.", //ERROR.PW.incorrect
+    empty: "비밀번호를 입력해주세요.", //ERROR.PW.empty
+  }
+}
+
+//API
+const API_URL = {
+  AUTH: {
+    signin: "https://bootcamp-api.codeit.kr/api/sign-in",
+    checkEmail: "https://bootcamp-api.codeit.kr/api/check-email",
+    signup: "https://bootcamp-api.codeit.kr/api/sign-up",
+  }
+}
+
 
 export {
     TEST_USER,
@@ -23,4 +51,6 @@ export {
     inputPw,
     pwConfirmWrap,
     inputPwConfirm,
+    ERROR,
+    API_URL,
 }

--- a/assets/js/const.js
+++ b/assets/js/const.js
@@ -1,0 +1,26 @@
+//TEST USER
+const TEST_USER = {
+    email: "test@codeit.com",
+    pw: "codeit101"
+  }
+
+//Element
+const formEl = document.querySelector('form');
+const emailWrap = document.querySelector('.sign__email__wrap');
+const inputEmail = document.querySelector('.input--email');
+const pwWrap = document.querySelector('.sign__pw__wrap');
+const inputPw = document.querySelector('.input--pw');
+const pwConfirmWrap = document.querySelector('.sign__pw__wrap--confirm')
+const inputPwConfirm = document.querySelector('.input--pw-confirm')
+
+
+export {
+    TEST_USER,
+    formEl,
+    emailWrap,
+    inputEmail,
+    pwWrap,
+    inputPw,
+    pwConfirmWrap,
+    inputPwConfirm,
+}

--- a/assets/js/const.js
+++ b/assets/js/const.js
@@ -25,6 +25,7 @@ const ERROR = {
     incorrect: "이메일을 확인해주세요.", //ERROR.EMAIL.incorrect
     empty: "이메일을 입력해주세요.", //ERROR.EMAIL.empty
     invalid: "올바른 이메일 주소가 아닙니다.", //ERROR.EMAIL.invalid
+    duplicated: "이미 사용 중인 이메일입니다.", //ERROR.EMAIL.duplicated
   },
   PW: {
     incorrect: "비밀번호를 확인해주세요.", //ERROR.PW.incorrect

--- a/assets/js/const.js
+++ b/assets/js/const.js
@@ -1,7 +1,7 @@
 //TEST USER
 const TEST_USER = {
     email: "test@codeit.com",
-    pw: "codeit101"
+    pw: "sprint101"
   }
 
 //Element

--- a/assets/js/signin.js
+++ b/assets/js/signin.js
@@ -57,13 +57,35 @@ inputPw.addEventListener('focusout', validatePwInput);
 function submitForm(e) {
   e.preventDefault()
 
-  const email = inputEmail.value;
-  const password = inputPw.value;
+  const email = inputEmail.value
+  const password = inputPw.value
 
-  if (email === TEST_USER.email && password === TEST_USER.pw) {
-    formEl.submit()
-    return;
+  const apiUrl = "https://bootcamp-api.codeit.kr/api/sign-in"
+  const inputAccount = {
+    email: email,
+    password: password,
   }
+
+  fetch (apiUrl, {
+    method: "POST", 
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(inputAccount)
+  })
+  .then((response) => {
+    if (response.ok) {
+      return response.json();
+    } else{
+      throw new Error('존재하지 않는 계정')
+    }
+  })
+  .then( (result) => {
+    formEl.submit()
+  })
+  .catch ((err) => {
+    console.log(err)
+  });
 
   removeElementOrNull(emailWrap, '.error');
   removeErrorClass(inputEmail);

--- a/assets/js/signin.js
+++ b/assets/js/signin.js
@@ -18,6 +18,13 @@ import {
 
 /*-----로그인 유효성 검사-----*/
 
+//accessToken 확인 후 이동
+let token = localStorage.getItem("accessToken") || null ;
+
+if (token) {
+  formEl.submit()
+}
+
 //이메일 유효성 검사
 function validateEmailInput(e) {
   removeElementOrNull(emailWrap, '.error');

--- a/assets/js/signin.js
+++ b/assets/js/signin.js
@@ -7,12 +7,13 @@ import {
 } from './utils.js';
 
 import {
-  TEST_USER,
   formEl,
   emailWrap,
   inputEmail,
   pwWrap,
-  inputPw
+  inputPw,
+  ERROR,
+  API_URL,
 } from './const.js';
 
 /*-----로그인 유효성 검사-----*/
@@ -25,10 +26,7 @@ function validateEmailInput(e) {
   const email = e.target.value;
 
   if (email == '' || !isEmailValid(email)) {
-
-    const emptyEmailError = "이메일을 입력해주세요."
-    const invalidEmailError = "올바른 이메일 주소가 아닙니다."
-    let tagMessage = (email == '') ? emptyEmailError : invalidEmailError;
+    let tagMessage = (email == '') ? ERROR.EMAIL.empty : ERROR.EMAIL.invalid;
 
     addErrorTag(inputEmail, emailWrap, tagMessage)
     return;
@@ -46,8 +44,7 @@ function validatePwInput(e) {
   const password = e.target.value;
 
   if (password == '') {
-    const emptyPwError = "비밀번호를 입력해주세요."
-    addErrorTag(inputPw, pwWrap, emptyPwError)
+    addErrorTag(inputPw, pwWrap, ERROR.PW.empty)
   }
 }
 
@@ -60,13 +57,12 @@ function submitForm(e) {
   const email = inputEmail.value
   const password = inputPw.value
 
-  const apiUrl = "https://bootcamp-api.codeit.kr/api/sign-in"
   const inputAccount = {
-    email: email,
-    password: password,
+    email,
+    password,
   }
 
-  fetch (apiUrl, {
+  fetch (API_URL.AUTH.signin, {
     method: "POST", 
     headers: {
       "Content-Type": "application/json"
@@ -74,29 +70,23 @@ function submitForm(e) {
     body: JSON.stringify(inputAccount)
   })
   .then((response) => {
-    if (response.ok) {
-      return response.json();
-    } else{
-      throw new Error('존재하지 않는 계정')
+    if (!response.ok) {
+     throw Error("This account is not exist")
     }
   })
-  .then( (result) => {
+  .then(() => {
     formEl.submit()
   })
   .catch ((err) => {
     console.log(err)
+    removeElementOrNull(emailWrap, '.error');
+    removeErrorClass(inputEmail);
+    removeElementOrNull(pwWrap, '.error');
+    removeErrorClass(inputPw);
+  
+    addErrorTag(inputEmail, emailWrap, ERROR.EMAIL.incorrect)
+    addErrorTag(inputPw, pwWrap, ERROR.PW.incorrect)
   });
-
-  removeElementOrNull(emailWrap, '.error');
-  removeErrorClass(inputEmail);
-  removeElementOrNull(pwWrap, '.error');
-  removeErrorClass(inputPw);
-
-  const incorrectEmailError = "이메일을 확인해주세요."
-  const incorrectPwError = "비밀번호를 확인해주세요."
-
-  addErrorTag(inputEmail, emailWrap, incorrectEmailError)
-  addErrorTag(inputPw, pwWrap, incorrectPwError)
 }
 
 formEl.addEventListener('submit', submitForm); //버튼 클릭시 실행

--- a/assets/js/signin.js
+++ b/assets/js/signin.js
@@ -65,13 +65,22 @@ function submitForm(e) {
   fetch (API_URL.AUTH.signin, {
     method: "POST", 
     headers: {
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
     },
     body: JSON.stringify(inputAccount)
   })
   .then((response) => {
+    console.log(response)
     if (!response.ok) {
      throw Error("This account is not exist")
+    }
+    return response.json()
+  })
+  .then((result) => {
+    //로그인 성공시 accessToken 저장
+    if (result.data.accessToken) {
+      localStorage.setItem('accessToken', result.data.accessToken)
+      localStorage.setItem('refreshToken', result.data.refreshToken)
     }
   })
   .then(() => {

--- a/assets/js/signin.js
+++ b/assets/js/signin.js
@@ -1,33 +1,36 @@
 import {
-  TEST_USER,
   isEmailValid,
   addErrorTag,
   removeErrorClass,
   removeElementOrNull,
-  togglePw} from './utils.js';
+  togglePw
+} from './utils.js';
 
-const signinForm = document.querySelector('form');
-const emailWrap = document.querySelector('.signin__email__wrap');
-const inputEmail = document.querySelector('.input--email');
-const pwWrap = document.querySelector('.signin__pw__wrap');
-const inputPw = document.querySelector('.input--pw');
+import {
+  TEST_USER,
+  formEl,
+  emailWrap,
+  inputEmail,
+  pwWrap,
+  inputPw
+} from './const.js';
 
 /*-----로그인 유효성 검사-----*/
 
 //이메일 유효성 검사
-function validateEmailInput(e){
+function validateEmailInput(e) {
   removeElementOrNull(emailWrap, '.error');
   removeErrorClass(inputEmail);
 
   const email = e.target.value;
 
   if (email == '' || !isEmailValid(email)) {
-    
+
     const emptyEmailError = "이메일을 입력해주세요."
     const invalidEmailError = "올바른 이메일 주소가 아닙니다."
-    let tagMessage = (email == '') ? emptyEmailError : invalidEmailError ;
-    
-    addErrorTag (inputEmail, emailWrap, tagMessage)
+    let tagMessage = (email == '') ? emptyEmailError : invalidEmailError;
+
+    addErrorTag(inputEmail, emailWrap, tagMessage)
     return;
   }
 }
@@ -36,13 +39,13 @@ inputEmail.addEventListener('focusout', validateEmailInput);
 
 
 //비밀번호 유효성 검사
-function validatePwInput(e){
+function validatePwInput(e) {
   removeElementOrNull(pwWrap, '.error');
   removeErrorClass(inputPw);
 
   const password = e.target.value;
-  
-  if (password == ''){
+
+  if (password == '') {
     const emptyPwError = "비밀번호를 입력해주세요."
     addErrorTag(inputPw, pwWrap, emptyPwError)
   }
@@ -51,14 +54,14 @@ function validatePwInput(e){
 inputPw.addEventListener('focusout', validatePwInput);
 
 //로그인 실행
-function submitForm(e){
+function submitForm(e) {
   e.preventDefault()
 
   const email = inputEmail.value;
   const password = inputPw.value;
 
-  if (email === TEST_USER.email && password === TEST_USER.pw){
-    signinForm.submit()
+  if (email === TEST_USER.email && password === TEST_USER.pw) {
+    formEl.submit()
     return;
   }
 
@@ -74,7 +77,7 @@ function submitForm(e){
   addErrorTag(inputPw, pwWrap, incorrectPwError)
 }
 
-signinForm.addEventListener('submit', submitForm); //버튼 클릭시 실행
+formEl.addEventListener('submit', submitForm); //버튼 클릭시 실행
 
 /*-----눈모양 아이콘 클릭에 따른 노출-----*/
 const eye = document.querySelector(".input__eye");

--- a/assets/js/signin.js
+++ b/assets/js/signin.js
@@ -3,7 +3,7 @@ import {
   addErrorTag,
   removeErrorClass,
   removeElementOrNull,
-  togglePw
+  togglePw,
 } from './utils.js';
 
 import {
@@ -59,7 +59,7 @@ function submitForm(e) {
 
   const inputAccount = {
     "email": email,
-    "password": password
+    "password": password,
   }
 
   fetch (API_URL.AUTH.signin, {

--- a/assets/js/signin.js
+++ b/assets/js/signin.js
@@ -58,8 +58,8 @@ function submitForm(e) {
   const password = inputPw.value
 
   const inputAccount = {
-    email,
-    password,
+    "email": email,
+    "password": password
   }
 
   fetch (API_URL.AUTH.signin, {

--- a/assets/js/signup.js
+++ b/assets/js/signup.js
@@ -7,42 +7,58 @@ import {
   togglePw, } from './utils.js';
   
 import {
-  TEST_USER,
   formEl,
   emailWrap,
   inputEmail,
   pwWrap,
   inputPw,
   pwConfirmWrap,
-  inputPwConfirm, } from './const.js';
+  inputPwConfirm,
+  ERROR,
+  API_URL,
+ } from './const.js';
 
 /*-----회원가입 유효성 검사-----*/
 //이메일 유효성 검사
+
 function validateEmailInput(email){
   removeElementOrNull(emailWrap, '.error');
   removeErrorClass(inputEmail);
+  let result = false
 
-  if (email == null || isEmailValid(email) === false || email === TEST_USER.email) {
-    
-    const emptyEmailError = "이메일을 입력해주세요."
-    const invalidEmailError = "올바른 이메일 주소가 아닙니다."
-    const takenEmailError = "이미 사용 중인 이메일입니다."
-    
-    let tagMessage = ''
-
-    if (email == null) {
-      tagMessage = emptyEmailError;
-    } else if (isEmailValid(email) === false){
-      tagMessage = invalidEmailError;
-    } else {
-      tagMessage = takenEmailError;
-    }
-    
+  if (email === ''){
+    let tagMessage = ERROR.EMAIL.empty;
+    addErrorTag (inputEmail, emailWrap, tagMessage);
+    return result;
+  } 
+  
+  if (isEmailValid(email) === false){
+    let tagMessage = ERROR.EMAIL.invalid;
     addErrorTag (inputEmail, emailWrap, tagMessage)
-    return false; //오류있음
+    return result;
   }
-  return true; //오류없음
+
+  fetch(API_URL.AUTH.checkEmail, {
+    method: 'POST',
+    headers: {
+      "Content-Type" : 'application/json',
+    },
+    body: JSON.stringify({"email": email}),
+  })
+  .then((response) => {
+    if(!response.ok) {
+      result = true;
+      throw Error("This email is already taken");
+    }
+  })
+  .catch ((err) => {
+    let tagMessage = ERROR.EMAIL.duplicated;
+    addErrorTag (inputEmail, emailWrap, tagMessage)
+  });
+
+  return result; //오류없음
 }
+
 
 inputEmail.addEventListener('focusout', (e) => {validateEmailInput(e.target.value)})
 

--- a/assets/js/signup.js
+++ b/assets/js/signup.js
@@ -1,37 +1,42 @@
 import {
-  TEST_USER,
   isEmailValid,
+  isPwValid,
   addErrorTag,
   removeErrorClass,
   removeElementOrNull,
-  togglePw } from './utils.js';
+  togglePw, } from './utils.js';
   
-  const signupForm = document.querySelector('form');
-  const emailWrap = document.querySelector('.signup__email__wrap');
-  const inputEmail = document.querySelector('.input--email');
-  const pwWrap = document.querySelector('.signup__pw__wrap');
-  const inputPw = document.querySelector('.input--pw');
-  const pwConfirmWrap = document.querySelector('.signup__pw__wrap--confirm')
-  const inputPwConfirm = document.querySelector('.input--pw-confirm')
-  
+import {
+  TEST_USER,
+  formEl,
+  emailWrap,
+  inputEmail,
+  pwWrap,
+  inputPw,
+  pwConfirmWrap,
+  inputPwConfirm, } from './const.js';
+
 /*-----회원가입 유효성 검사-----*/
 //이메일 유효성 검사
 function validateEmailInput(email){
   removeElementOrNull(emailWrap, '.error');
   removeErrorClass(inputEmail);
 
-  if (email == '' || !isEmailValid(email) || email == TEST_USER.email) {
+  if (email == null || isEmailValid(email) === false || email === TEST_USER.email) {
     
     const emptyEmailError = "이메일을 입력해주세요."
     const invalidEmailError = "올바른 이메일 주소가 아닙니다."
     const takenEmailError = "이미 사용 중인 이메일입니다."
     
-    let tagMessage =
-    (email == '') 
-    ? emptyEmailError 
-    : (!isEmailValid(email)) 
-    ? invalidEmailError 
-    : takenEmailError;
+    let tagMessage = ''
+
+    if (email == null) {
+      tagMessage = emptyEmailError;
+    } else if (isEmailValid(email) === false){
+      tagMessage = invalidEmailError;
+    } else {
+      tagMessage = takenEmailError;
+    }
     
     addErrorTag (inputEmail, emailWrap, tagMessage)
     return false; //오류있음
@@ -41,14 +46,7 @@ function validateEmailInput(email){
 
 inputEmail.addEventListener('focusout', (e) => {validateEmailInput(e.target.value)})
 
-const PW_REGEXP = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/;
-
-function isPwValid(password) {
-  return PW_REGEXP.test(password);
-}
-
 //비밀번호 유효성 검사
-
 function validatePwInput(password){
   removeElementOrNull(pwWrap, '.error');
   removeErrorClass(inputPw);
@@ -56,7 +54,7 @@ function validatePwInput(password){
   if (password == '' || !isPwValid(password)){
     const emptyPwError = "비밀번호를 입력해주세요."
     const invalidPwError = "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요."
-    let tagMessage = (password == '') ? emptyPwError : invalidPwError;
+    const tagMessage = (password == '') ? emptyPwError : invalidPwError;
 
     addErrorTag(inputPw, pwWrap, tagMessage)
     return false; //오류있음
@@ -71,14 +69,14 @@ function confirmPw(){
   removeElementOrNull(pwConfirmWrap, '.error');
   removeErrorClass(inputPwConfirm);
 
-  let password01 = inputPw.value;
-  let password02 = inputPwConfirm.value;
+  const password = inputPw.value;
+  const confirmPassword = inputPwConfirm.value;
 
-  if (password02 == '') {
+  if (confirmPassword == '') {
     return false
   }
 
-  let isPwMatch = password01 === password02;
+  const isPwMatch = password === confirmPassword;
 
   if (!isPwMatch) {
     const mismatchPwError = "비밀번호가 일치하지 않아요."
@@ -106,16 +104,15 @@ function submitForm(e){
   let isPwMatch = confirmPw();
 
   if (isValidEmail && isValidPw && isPwMatch) {
-    signupForm.submit()
+    formEl.submit()
   }
 }
 
-signupForm.addEventListener('submit', submitForm); //버튼 클릭시 실행
+formEl.addEventListener('submit', submitForm); //버튼 클릭시 실행
 
 //비밀번호 숨기기 보이기
 const eyes = document.querySelectorAll(".input__eye");
 
-for (let i = 0 ; i < eyes.length ; i++) {
-  let eye = eyes[i]
-  eye.addEventListener('click', togglePw)
-}
+eyes.forEach((eye) => {
+  eye.addEventListener('click', togglePw);
+});

--- a/assets/js/signup.js
+++ b/assets/js/signup.js
@@ -19,8 +19,15 @@ import {
  } from './const.js';
 
 /*-----회원가입 유효성 검사-----*/
-//이메일 유효성 검사
 
+//accessToken 확인 후 이동
+let token = localStorage.getItem("accessToken") || null ;
+
+if (token) {
+  formEl.submit()
+}
+
+//이메일 유효성 검사
 function validateEmailInput(email){
   removeElementOrNull(emailWrap, '.error');
   removeErrorClass(inputEmail);

--- a/assets/js/signup.js
+++ b/assets/js/signup.js
@@ -24,19 +24,20 @@ import {
 function validateEmailInput(email){
   removeElementOrNull(emailWrap, '.error');
   removeErrorClass(inputEmail);
-  let result = false
 
   if (email === ''){
     let tagMessage = ERROR.EMAIL.empty;
     addErrorTag (inputEmail, emailWrap, tagMessage);
-    return result;
+    return false;
   } 
   
   if (isEmailValid(email) === false){
     let tagMessage = ERROR.EMAIL.invalid;
     addErrorTag (inputEmail, emailWrap, tagMessage)
-    return result;
+    return false;
   }
+
+let result = true
 
   fetch(API_URL.AUTH.checkEmail, {
     method: 'POST',
@@ -47,16 +48,17 @@ function validateEmailInput(email){
   })
   .then((response) => {
     if(!response.ok) {
-      result = true;
+      result = false;
       throw Error("This email is already taken");
     }
   })
   .catch ((err) => {
     let tagMessage = ERROR.EMAIL.duplicated;
     addErrorTag (inputEmail, emailWrap, tagMessage)
-  });
-
-  return result; //오류없음
+  })
+  .finally ( () => {
+    return result;
+});
 }
 
 

--- a/assets/js/signup.js
+++ b/assets/js/signup.js
@@ -30,37 +30,37 @@ function validateEmailInput(email){
     addErrorTag (inputEmail, emailWrap, tagMessage);
     return false;
   } 
-  
+
   if (isEmailValid(email) === false){
     let tagMessage = ERROR.EMAIL.invalid;
     addErrorTag (inputEmail, emailWrap, tagMessage)
     return false;
   }
 
-let result = true
+  let result = true
 
-  fetch(API_URL.AUTH.checkEmail, {
+  const checkEmail = function () {
+    fetch(API_URL.AUTH.checkEmail, {
     method: 'POST',
     headers: {
       "Content-Type" : 'application/json',
     },
     body: JSON.stringify({"email": email}),
-  })
-  .then((response) => {
-    if(!response.ok) {
-      result = false;
-      throw Error("This email is already taken");
-    }
-  })
-  .catch ((err) => {
-    let tagMessage = ERROR.EMAIL.duplicated;
-    addErrorTag (inputEmail, emailWrap, tagMessage)
-  })
-  .finally ( () => {
-    return result;
-});
+    })
+    .then((response) => {
+      if(!response.ok) {
+        result = false;
+        throw Error("This email is already taken");
+      }
+    })
+    .catch ((err) => {
+      let tagMessage = ERROR.EMAIL.duplicated;
+      addErrorTag (inputEmail, emailWrap, tagMessage)
+    })
+    return result
+  }
+  return (checkEmail());
 }
-
 
 inputEmail.addEventListener('focusout', (e) => {validateEmailInput(e.target.value)})
 
@@ -106,23 +106,45 @@ function confirmPw(){
 }
 
 inputPwConfirm.addEventListener('focusout', confirmPw)
-inputPw.addEventListener('focusout',confirmPw)
+inputPw.addEventListener('focusout',confirmPw) //비밀번호 입력칸에서 수정 발생시 재검사
 
 //회원가입 실행
 function submitForm(e){
   e.preventDefault()
 
-  //이메일 검사
-  const email = inputEmail.value;
-  let isValidEmail = validateEmailInput(email)
+  const email = inputEmail.value
+  const password = inputPw.value
 
-  //비밀번호 검사
-  const password01 = inputPw.value;
-  let isValidPw = validatePwInput(password01)
+  const inputAccount = {
+    "email": email,
+    "password": password
+  }
+
+  //이메일&비밀번호 검사
+  let isValidEmail = validateEmailInput(email)
+  let isValidPw = validatePwInput(password)
   let isPwMatch = confirmPw();
 
+  //모두 true면 submit
   if (isValidEmail && isValidPw && isPwMatch) {
-    formEl.submit()
+    fetch (API_URL.AUTH.signup, {
+      method: "POST", 
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(inputAccount)
+    })
+    .then((response) => {
+      if (!response.ok) {
+       throw Error("This account is not available")
+      }
+    })
+    .then(() => {
+      formEl.submit()
+    })
+    .catch ((err) => {
+      console.log(err)
+    });
   }
 }
 

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -1,5 +1,5 @@
 //정규식
-const EMAIL_REGEXP = /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
+const EMAIL_REGEXP = /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,}$/i;
 const PW_REGEXP = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/;
 
 //이메일 유효 형식 검사

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -1,14 +1,15 @@
-//TEST USER
-const TEST_USER = {
-  email: "test@codeit.com",
-  pw: "codeit101"
-}
+//정규식
+const EMAIL_REGEXP = /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
+const PW_REGEXP = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/;
 
 //이메일 유효 형식 검사
-const EMAIL_REGEXP = /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
-
 function isEmailValid(email){
   return (email.match(EMAIL_REGEXP)!=null);
+}
+
+//비밀번호 유효 형식 검사
+function isPwValid(password) {
+  return PW_REGEXP.test(password);
 }
 
 //에러 태그 생성
@@ -32,17 +33,17 @@ function removeErrorClass(element) {
   
 //특정 범위 내 요소 있으면 제거
 function removeElementOrNull(range, element){
-if (range.querySelector(element)){
-  let temp = range.querySelector(element);
-  temp.remove();
+  if (range.querySelector(element)){
+    const el = range.querySelector(element);
+    el.remove();
   }
 }
 
 //ErrorTag
 function addErrorTag (el, insertionPoint, message) {
-  const SpanTag = createErrorTag();
-  SpanTag.textContent = message;
-  insertionPoint.appendChild(SpanTag);
+  const spanTag = createErrorTag();
+  spanTag.textContent = message;
+  insertionPoint.appendChild(spanTag);
   addErrorClass(el);
 }
 
@@ -68,8 +69,8 @@ function togglePw(e){
 }
 
 export { 
-  TEST_USER,
   isEmailValid,
+  isPwValid,
   addErrorTag,
   removeErrorClass,
   removeElementOrNull,

--- a/signin.html
+++ b/signin.html
@@ -26,15 +26,15 @@
     </div>
 
     <form class="signin__wrap" action="/folder">
-      <div class="signin__email__wrap">
-        <label class="signin__label">이메일</label>
-        <div class="signin__input__wrap">
+      <div class="sign__email__wrap">
+        <label class="sign__label">이메일</label>
+        <div class="input__box">
           <input class="input__row input--email" autocomplete="off">
         </div>
       </div>
-      <div class="signin__pw__wrap">
-        <label class="signin__label">비밀번호</label>
-        <div class="signin__input__wrap">
+      <div class="sign__pw__wrap">
+        <label class="sign__label">비밀번호</label>
+        <div class="input__box">
           <input class="input__row input--pw" type="password" autocomplete="off">
           <img class="input__eye" src="assets/img/icon-eye-off.svg" alt="password eye off">
         </div>
@@ -42,9 +42,9 @@
       <button class="signin__btn">로그인</button>
     </form>
     
-    <div class="signin--social">
+    <div class="sign--social">
       소셜 로그인
-      <ul class="signin--social-icon">
+      <ul class="sign--social-icon">
         <li><a href="https://www.google.com/"><img src="./assets/img/icon-google-circle.svg" alt="Google signin icon" width="42" height="42"></a></li>
         <li><a href="https://www.kakaocorp.com/page/"><img src="./assets/img/icon-kakaotalk-circle.svg" alt="Kakaotalk signin icon" width="42" height="42"></a></li>
       </ul>

--- a/signin.html
+++ b/signin.html
@@ -39,7 +39,7 @@
           <img class="input__eye" src="assets/img/icon-eye-off.svg" alt="password eye off">
         </div>
       </div> 
-      <button class="signin__btn">로그인</button>
+      <button class="signin__btn" type="submit">로그인</button>
     </form>
     
     <div class="sign--social">

--- a/signup.html
+++ b/signup.html
@@ -26,22 +26,22 @@
     </div>
 
     <form class="signup__wrap" action="/folder">
-      <div class="signup__email__wrap">
-        <label class="signup__label">이메일</label>
-        <div class="signup__input__wrap">
+      <div class="sign__email__wrap">
+        <label class="sign__label">이메일</label>
+        <div class="input__box">
           <input class="input__row input--email" type="text" autocomplete="off">
         </div>
       </div>
-      <div class="signup__pw__wrap">
-        <label class="signup__label">비밀번호</label>
-        <div class="signup__input__wrap">
+      <div class="sign__pw__wrap">
+        <label class="sign__label">비밀번호</label>
+        <div class="input__box">
           <input class="input__row input--pw" type="password" autocomplete="off"> <!--type="password"-->
           <img class="input__eye" src="assets/img/icon-eye-off.svg" alt="password eye off">
         </div>
       </div>
-      <div class="signup__pw__wrap--confirm">
+      <div class="sign__pw__wrap--confirm">
         <label class="signup__label">비밀번호 확인</label>
-        <div class="signup__input__wrap">
+        <div class="input__box">
           <input class="input__row input--pw-confirm" type="password" autocomplete="off"> <!--type="password"-->
           <img class="input__eye" src="assets/img/icon-eye-off.svg" alt="password eye off">
         </div>
@@ -49,9 +49,9 @@
        <button class="signup__btn" type="submit">회원가입</button>
     </form>
     
-    <div class="signup--social">
+    <div class="sign--social">
       다른 방식으로 가입하기
-      <ul class="signup--social-icon">
+      <ul class="sign--social-icon">
         <li><a href="https://www.google.com/"><img src="./assets/img/icon-google-circle.svg" alt="sign-up with Google" width="42" height="42"></a></li>
         <li><a href="https://www.kakaocorp.com/page/"><img src="./assets/img/icon-kakaotalk-circle.svg" alt="sign-up with Kakaotalk" width="42" height="42"></a></li>
       </ul>


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [로그인 페이지] https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “test@codeit.com”, “password”: “sprint101” } POST 요청해서 성공 응답을 받고 “/folder”로 이동하나요?
- [X] [회원가입 페이지] 이메일 input에서 “test@codeit.com”으로 “/api/check-email” 이메일 중복 확인 POST 요청하면 이메일 중복 에러를 확인할 수 있나요?
- [X] [회원가입 페이지] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?

### 심화
- [X] [심화] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?
- [X] [심화] 로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 “/folder” 페이지로 이동하나요?

## 주요 변경사항
- 로그인/회원가입 API 구현
- access token 발급, 저장, 확인

## 멘토에게
[10/15]
- 중복 이메일 검사에서 원하는 동작이 나오지 않네요. 계속 고민하겠습니다.
- 심화 기능은 구현 방법을 전혀 모르겠습니다...!

[10/19]
- 기본, 심화 기능 구현했습니다!