### PR TITLE
[송민혁] week6

### DIFF
--- a/js/signin.js
+++ b/js/signin.js
@@ -11,10 +11,7 @@ const $passwordConfirmErrorMessage = document.querySelector(
 let eyeOn = false;
 const EMAIL_REGEX = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g;
 const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
-const TEST_USER = {
-  email: "test@codeit.com",
-  password: "codeit101",
-};
+
 const API = "https://bootcamp-api.codeit.kr/api";
 
 // 토큰 존재하는 경우
@@ -67,7 +64,6 @@ const submitForm = async (event) => {
       }),
     });
     const responseData = await response.json();
-
     if (response.status === 200) {
       // 토큰 추가
       localStorage.setItem("accessToken", responseData.accessToken);

--- a/js/signin.js
+++ b/js/signin.js
@@ -9,9 +9,14 @@ const passwordConfirmErrorMessage = document.querySelector(
 );
 
 let eyeOn = false;
+const EMAIL_REGEX = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g;
+const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+const TEST_USER = {
+  email: "test@codeit.com",
+  password: "codeit101",
+};
 
-const checkEmailError = (event) => {
-  const EMAIL_REGEX = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g;
+const checkEmailValidation = (event) => {
   if (event.target.value === "") {
     emailErrorMessage.style.display = "block";
     emailErrorMessage.textContent = "이메일을 입력해주세요";
@@ -26,16 +31,12 @@ const checkEmailError = (event) => {
   }
 };
 
-const checkPasswordError = (event) => {
-  const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+const checkPasswordValidation = (event) => {
   if (event.target.value === "") {
     passwordErrorMessage.style.display = "block";
     passwordErrorMessage.textContent = "비밀번호를 입력해주세요";
     password.classList.add("border-red");
-  } else if (
-    event.target.value.length < 8 ||
-    !PASSWORD_REGEX.test(event.target.value)
-  ) {
+  } else if (!PASSWORD_REGEX.test(event.target.value)) {
     passwordErrorMessage.style.display = "block";
     passwordErrorMessage.textContent =
       "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요";
@@ -48,7 +49,10 @@ const checkPasswordError = (event) => {
 
 const submitForm = (event) => {
   event.preventDefault();
-  if (email.value === "test@codeit.com" && password.value === "codeit101") {
+  if (
+    email.value === TEST_USER.email &&
+    password.value === TEST_USER.password
+  ) {
     location.href = "/pages/folder.html";
   } else {
     checkEmailError();
@@ -70,16 +74,9 @@ const togglePassword = (input, toggleButton) => {
     .setAttribute("src", "/assets/eye-off.svg");
 };
 
-email.addEventListener("focusout", checkEmailError);
-password.addEventListener("focusout", checkPasswordError);
+email.addEventListener("focusout", checkEmailValidation);
+password.addEventListener("focusout", checkPasswordValidation);
 passwordEye.addEventListener("click", () =>
   togglePassword(password, passwordEye)
 );
 signButton.addEventListener("submit", submitForm);
-document.addEventListener("keydown", function (event) {
-  if (event.key === "Enter") {
-    submitForm();
-  }
-});
-
-// 모듈화 안 됨

--- a/js/signin.js
+++ b/js/signin.js
@@ -1,10 +1,10 @@
-const email = document.querySelector(".email-input");
-const password = document.querySelector(".password-input");
-const signButton = document.querySelector(".sign-form");
-const passwordEye = document.querySelector("#password-toggle");
-const emailErrorMessage = document.querySelector(".email-error-message");
-const passwordErrorMessage = document.querySelector(".password-error-message");
-const passwordConfirmErrorMessage = document.querySelector(
+const $email = document.querySelector(".email-input");
+const $password = document.querySelector(".password-input");
+const $signButton = document.querySelector(".sign-form");
+const $passwordEye = document.querySelector("#password-toggle");
+const $emailErrorMessage = document.querySelector(".email-error-message");
+const $passwordErrorMessage = document.querySelector(".password-error-message");
+const $passwordConfirmErrorMessage = document.querySelector(
   ".passwordCheck-error-message"
 );
 
@@ -15,48 +15,68 @@ const TEST_USER = {
   email: "test@codeit.com",
   password: "codeit101",
 };
+const API = "https://bootcamp-api.codeit.kr/api";
+
+// 토큰 존재하는 경우
+if (localStorage.getItem("accessToken")) {
+  location.href = "/pages/folder.html";
+}
 
 const checkEmailValidation = (event) => {
   if (event.target.value === "") {
-    emailErrorMessage.style.display = "block";
-    emailErrorMessage.textContent = "이메일을 입력해주세요";
-    email.classList.add("border-red");
+    $emailErrorMessage.style.display = "block";
+    $emailErrorMessage.textContent = "이메일을 입력해주세요";
+    $email.classList.add("border-red");
   } else if (!EMAIL_REGEX.test(event.target.value)) {
-    emailErrorMessage.style.display = "block";
-    emailErrorMessage.textContent = "올바른 이메일을 입력해주세요";
-    email.classList.add("border-red");
+    $emailErrorMessage.style.display = "block";
+    $emailErrorMessage.textContent = "올바른 이메일을 입력해주세요";
+    $email.classList.add("border-red");
   } else {
-    emailErrorMessage.style.display = "none";
-    email.classList.remove("border-red");
+    $emailErrorMessage.style.display = "none";
+    $email.classList.remove("border-red");
   }
 };
 
 const checkPasswordValidation = (event) => {
   if (event.target.value === "") {
-    passwordErrorMessage.style.display = "block";
-    passwordErrorMessage.textContent = "비밀번호를 입력해주세요";
-    password.classList.add("border-red");
+    $passwordErrorMessage.style.display = "block";
+    $passwordErrorMessage.textContent = "비밀번호를 입력해주세요";
+    $password.classList.add("border-red");
   } else if (!PASSWORD_REGEX.test(event.target.value)) {
-    passwordErrorMessage.style.display = "block";
-    passwordErrorMessage.textContent =
+    $passwordErrorMessage.style.display = "block";
+    $passwordErrorMessage.textContent =
       "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요";
-    password.classList.add("border-red");
+    $password.classList.add("border-red");
   } else {
-    passwordErrorMessage.style.display = "none";
-    passwordCheck.classList.remove("border-red");
+    $passwordErrorMessage.style.display = "none";
+    $passwordCheck.classList.remove("border-red");
   }
 };
 
-const submitForm = (event) => {
+const submitForm = async (event) => {
   event.preventDefault();
-  if (
-    email.value === TEST_USER.email &&
-    password.value === TEST_USER.password
-  ) {
-    location.href = "/pages/folder.html";
-  } else {
-    checkEmailError();
-    checkPasswordError();
+  try {
+    const response = await fetch(`${API}/sign-in`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        email: $email.value,
+        password: $password.value,
+      }),
+    });
+    const responseData = await response.json();
+
+    if (response.status === 200) {
+      // 토큰 추가
+      localStorage.setItem("accessToken", responseData.accessToken);
+      window.location.href = "/pages/folder.html";
+    } else if (response.status === 400) {
+      alert("아이디 혹은 비밀번호를 확인해주세요");
+    }
+  } catch (err) {
+    console.log(err);
   }
 };
 
@@ -74,9 +94,9 @@ const togglePassword = (input, toggleButton) => {
     .setAttribute("src", "/assets/eye-off.svg");
 };
 
-email.addEventListener("focusout", checkEmailValidation);
-password.addEventListener("focusout", checkPasswordValidation);
-passwordEye.addEventListener("click", () =>
-  togglePassword(password, passwordEye)
+$email.addEventListener("focusout", checkEmailValidation);
+$password.addEventListener("focusout", checkPasswordValidation);
+$passwordEye.addEventListener("click", () =>
+  togglePassword($password, $passwordEye)
 );
-signButton.addEventListener("submit", submitForm);
+$signButton.addEventListener("submit", submitForm);

--- a/js/signup.js
+++ b/js/signup.js
@@ -19,9 +19,14 @@ const passwordConfirmErrorMessage = document.querySelector(
 );
 const signForm = document.querySelector(".sign-form");
 let eyeOn = false;
+const EMAIL_REGEX = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g;
+const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+const TEST_USER = {
+  email: "test@codeit.com",
+  password: "codeit101",
+};
 
-const checkEmailError = (event) => {
-  const EMAIL_REGEX = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g;
+const checkEmailValidation = (event) => {
   if (event.target.value === "") {
     emailErrorMessage.style.display = "block";
     emailErrorMessage.textContent = "이메일을 입력해주세요";
@@ -39,17 +44,13 @@ const checkEmailError = (event) => {
   }
 };
 
-const checkPasswordError = (event) => {
-  const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+const checkPasswordValidation = (event) => {
   if (event.target.value === "") {
     passwordErrorMessage.style.display = "block";
     passwordErrorMessage.textContent = "비밀번호를 입력해주세요";
     password.classList.add("border-red");
     return false;
-  } else if (
-    event.target.value.length < 8 ||
-    !PASSWORD_REGEX.test(event.target.value)
-  ) {
+  } else if (!PASSWORD_REGEX.test(event.target.value)) {
     passwordErrorMessage.style.display = "block";
     passwordErrorMessage.textContent =
       "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요";
@@ -62,7 +63,7 @@ const checkPasswordError = (event) => {
   }
 };
 
-const checkPasswordConfirmError = (event) => {
+const checkPasswordConfirmValidation = (event) => {
   if (event.target.value === password.value) {
     passwordConfirmErrorMessage.style.display = "none";
     passwordConfirm.classList.remove("border-red");
@@ -92,16 +93,16 @@ const togglePassword = (input, toggleButton) => {
 const submitForm = (event) => {
   event.preventDefault();
   const isVaildUser =
-    email.value === "test@codeit.com" && password.value === "codeit101";
+    email.value === TEST_USER.email && password.value === TEST_USER.password;
   if (isVaildUser) {
     location.href = "/pages/folder.html";
     return;
   }
 };
 
-email.addEventListener("focusout", checkEmailError);
-password.addEventListener("focusout", checkPasswordError);
-passwordConfirm.addEventListener("focusout", checkPasswordConfirmError);
+email.addEventListener("focusout", checkEmailValidation);
+password.addEventListener("focusout", checkPasswordValidation);
+passwordConfirm.addEventListener("focusout", checkPasswordConfirmValidation);
 passwordEye.addEventListener("click", () =>
   togglePassword(password, passwordEye)
 );

--- a/js/signup.js
+++ b/js/signup.js
@@ -54,7 +54,7 @@ const checkPasswordValidation = (event) => {
 };
 
 const checkPasswordConfirmValidation = (event) => {
-  if (event.target.value === password.value) {
+  if (event.target.value === $password.value) {
     $passwordConfirmErrorMessage.style.display = "none";
     $passwordConfirm.classList.remove("border-red");
     return true;
@@ -80,13 +80,34 @@ const togglePassword = (input, toggleButton) => {
     .setAttribute("src", "/assets/eye-off.svg");
 };
 
-const submitForm = (event) => {
+const submitForm = async (event) => {
   event.preventDefault();
-  const isVaildUser =
-    email.value === TEST_USER.email && password.value === TEST_USER.password;
-  if (isVaildUser) {
-    location.href = "/pages/folder.html";
-    return;
+  try {
+    if (
+      checkPasswordValidation &&
+      checkPasswordValidation &&
+      checkPasswordConfirmValidation
+    ) {
+      const response = await fetch(`${API}/sign-up`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: $email.value,
+          password: $password.value,
+        }),
+      });
+      const responseData = await response.json();
+      if (response.status === 200) {
+        localStorage.setItem("accessToken", responseData.accessToken);
+        window.location.href = "/pages/folder.html";
+      } else {
+        alert("회원가입을 실패했습니다. 다시 작성하시오.");
+      }
+    }
+  } catch (err) {
+    console.log(err);
   }
 };
 
@@ -94,9 +115,9 @@ $email.addEventListener("focusout", checkEmailValidation);
 $password.addEventListener("focusout", checkPasswordValidation);
 $passwordConfirm.addEventListener("focusout", checkPasswordConfirmValidation);
 $passwordEye.addEventListener("click", () =>
-  togglePassword(password, passwordEye)
+  togglePassword($password, $passwordEye)
 );
 $passwordConfirmEye.addEventListener("click", () =>
-  togglePassword(passwordConfirm, passwordEye)
+  togglePassword($passwordConfirm, $passwordEye)
 );
 $signForm.addEventListener("submit", submitForm);

--- a/js/signup.js
+++ b/js/signup.js
@@ -88,22 +88,36 @@ const submitForm = async (event) => {
       checkPasswordValidation &&
       checkPasswordConfirmValidation
     ) {
-      const response = await fetch(`${API}/sign-up`, {
+      const duplicateIdResponse = await fetch(`${API}/check-email`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
           email: $email.value,
-          password: $password.value,
         }),
       });
-      const responseData = await response.json();
-      if (response.status === 200) {
-        localStorage.setItem("accessToken", responseData.accessToken);
-        window.location.href = "/pages/folder.html";
-      } else {
-        alert("회원가입을 실패했습니다. 다시 작성하시오.");
+      const duplicateIdResponseData = await duplicateIdResponse.json();
+      if (duplicateIdResponse.status === 409) {
+        alert("이미 사용중인 이메일입니다.");
+      } else if (duplicateIdResponse.status === 200) {
+        const signUpResponse = await fetch(`${API}/sign-up`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            email: $email.value,
+            password: $password.value,
+          }),
+        });
+        const signUpResponseData = await signUpResponse.json();
+        if (signUpResponse.status === 200) {
+          localStorage.setItem("accessToken", signUpResponseData.accessToken);
+          window.location.href = "/pages/folder.html";
+        } else {
+          alert("회원가입을 실패했습니다. 다시 작성하시오.");
+        }
       }
     }
   } catch (err) {

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,77 +1,67 @@
-// import {
-//   checkEmailError,
-//   checkPasswordError,
-//   checkPasswordConfirmError,
-//   checkSignin,
-//   togglePassword,
-//   TEST_USER,
-// } from "./utils.js";
-
-const email = document.querySelector(".email-input");
-const password = document.querySelector(".password-input");
-const passwordConfirm = document.querySelector(".passwordConfirm-input");
-const passwordEye = document.querySelector("#password-toggle");
-const passwordConfirmEye = document.querySelector("#password-check-toggle");
-const emailErrorMessage = document.querySelector(".email-error-message");
-const passwordErrorMessage = document.querySelector(".password-error-message");
-const passwordConfirmErrorMessage = document.querySelector(
+const $email = document.querySelector(".email-input");
+const $password = document.querySelector(".password-input");
+const $passwordConfirm = document.querySelector(".passwordConfirm-input");
+const $passwordEye = document.querySelector("#password-toggle");
+const $passwordConfirmEye = document.querySelector("#password-check-toggle");
+const $emailErrorMessage = document.querySelector(".email-error-message");
+const $passwordErrorMessage = document.querySelector(".password-error-message");
+const $passwordConfirmErrorMessage = document.querySelector(
   ".passwordConfirm-error-message"
 );
-const signForm = document.querySelector(".sign-form");
+const $signForm = document.querySelector(".sign-form");
+
 let eyeOn = false;
 const EMAIL_REGEX = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g;
 const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
-const TEST_USER = {
-  email: "test@codeit.com",
-  password: "codeit101",
-};
+
+const API = "https://bootcamp-api.codeit.kr/api";
 
 const checkEmailValidation = (event) => {
   if (event.target.value === "") {
-    emailErrorMessage.style.display = "block";
-    emailErrorMessage.textContent = "이메일을 입력해주세요";
-    email.classList.add("border-red");
+    $emailErrorMessage.style.display = "block";
+    $emailErrorMessage.textContent = "이메일을 입력해주세요";
+    $email.classList.add("border-red");
     return false;
   } else if (!EMAIL_REGEX.test(event.target.value)) {
-    emailErrorMessage.style.display = "block";
-    emailErrorMessage.textContent = "올바른 이메일을 입력해주세요";
-    email.classList.add("border-red");
+    $emailErrorMessage.style.display = "block";
+    $emailErrorMessage.textContent = "올바른 이메일을 입력해주세요";
+    $email.classList.add("border-red");
     return false;
   } else {
-    emailErrorMessage.style.display = "none";
-    email.classList.remove("border-red");
+    $emailErrorMessage.style.display = "none";
+    $email.classList.remove("border-red");
     return true;
   }
 };
 
 const checkPasswordValidation = (event) => {
   if (event.target.value === "") {
-    passwordErrorMessage.style.display = "block";
-    passwordErrorMessage.textContent = "비밀번호를 입력해주세요";
-    password.classList.add("border-red");
+    $passwordErrorMessage.style.display = "block";
+    $passwordErrorMessage.textContent = "비밀번호를 입력해주세요";
+    $password.classList.add("border-red");
     return false;
   } else if (!PASSWORD_REGEX.test(event.target.value)) {
-    passwordErrorMessage.style.display = "block";
-    passwordErrorMessage.textContent =
+    $passwordErrorMessage.style.display = "block";
+    $passwordErrorMessage.textContent =
       "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요";
-    password.classList.add("border-red");
+    $password.classList.add("border-red");
     return false;
   } else {
-    passwordErrorMessage.style.display = "none";
-    passwordCheck.classList.remove("border-red");
+    $passwordErrorMessage.style.display = "none";
+    $passwordCheck.classList.remove("border-red");
     return true;
   }
 };
 
 const checkPasswordConfirmValidation = (event) => {
   if (event.target.value === password.value) {
-    passwordConfirmErrorMessage.style.display = "none";
-    passwordConfirm.classList.remove("border-red");
+    $passwordConfirmErrorMessage.style.display = "none";
+    $passwordConfirm.classList.remove("border-red");
     return true;
   } else {
-    passwordConfirmErrorMessage.style.display = "block";
-    passwordConfirmErrorMessage.textContent = "비밀번호가 일치하지 않아요";
-    passwordConfirm.classList.add("border-red");
+    $passwordConfirmErrorMessage.style.display = "block";
+    $passwordConfirmErrorMessage.textContent = "비밀번호가 일치하지 않아요";
+    $passwordConfirm.classList.add("border-red");
     return false;
   }
 };
@@ -100,20 +90,13 @@ const submitForm = (event) => {
   }
 };
 
-email.addEventListener("focusout", checkEmailValidation);
-password.addEventListener("focusout", checkPasswordValidation);
-passwordConfirm.addEventListener("focusout", checkPasswordConfirmValidation);
-passwordEye.addEventListener("click", () =>
+$email.addEventListener("focusout", checkEmailValidation);
+$password.addEventListener("focusout", checkPasswordValidation);
+$passwordConfirm.addEventListener("focusout", checkPasswordConfirmValidation);
+$passwordEye.addEventListener("click", () =>
   togglePassword(password, passwordEye)
 );
-passwordConfirmEye.addEventListener("click", () =>
+$passwordConfirmEye.addEventListener("click", () =>
   togglePassword(passwordConfirm, passwordEye)
 );
-signForm.addEventListener("submit", submitForm);
-
-// 아래 코드에 대해 실패해서 일일이 이벤트 등록
-// for (let passwordEye of passwordEyes) {
-//   passwordEye.addEventListener("click", () =>
-//     togglePassword(password, passwordEye)
-//   );
-// }
+$signForm.addEventListener("submit", submitForm);


### PR DESCRIPTION
## 요구사항

### 기본

- [x] https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “test@codeit.com”, “password”: “sprint101” } POST 요청해서 성공 응답을 받고 “/folder”로 이동하나요?


- [x] 이메일 input에서 “test@codeit.com”으로 “/api/check-email” 이메일 중복 확인 POST 요청하면 이메일 중복 에러를 확인할 수 있나요?


- [x] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?

### 심화

- [x] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?


- [x] 로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 “/folder” 페이지로 이동하나요?

## 주요 변경사항

- fetchAPI를 이용해서 서버에게  POST 요청하기
- 리스폰스의 상태에 따른 로그인, 회원가입, 이메일 중복 확인 기능 추가

## 스크린샷

![image](https://github.com/codeit-bootcamp-frontend/1-Weekly-Mission/assets/98685266/eec77c8a-d0d7-4b6f-abe7-08abe48bbd6c)

액세스토큰이 있는 경우 자동으로 /folder 페이지로 이동한 이미지

![이메일중복확인](https://github.com/codeit-bootcamp-frontend/1-Weekly-Mission/assets/98685266/34f948c6-79e5-478f-b9c3-37607f8edefa)

이메일 중복 확인 

## 멘토에게

- 마지막인데 이런 식으로 제출해서 마음이 걸립니다.
절차지향식의 코드를 작성했는데 모듈화해서 잘 정돈해서 보냈어야 했는데 부족한 점이 보여서 아쉽습니다. 
그리고 accessToken을 추가하긴 했지만 어떤 상황에서 제거해야 하는지 고민하다가 제출합니다. 
추가적으로 alert 함수로 실패 상황(status가 200이 아닌 경우)을 나타냈는데 이렇게 해도 되는지와 멘토님이 생각하는 해결방안이 궁금합니다. 
