### PR TITLE
[전수빈] week15

### DIFF
--- a/components/button/Button.tsx
+++ b/components/button/Button.tsx
@@ -4,10 +4,15 @@ import { ButtonContainer } from "./buttonStyled";
 interface ButtonProps {
   children: ReactNode;
   onClick?: (e: React.MouseEvent) => void;
+  type?: "button" | "submit";
 }
 
-const Button = ({ children, onClick }: ButtonProps) => {
-  return <ButtonContainer onClick={onClick}>{children}</ButtonContainer>;
+const Button = ({ children, onClick, type = "button" }: ButtonProps) => {
+  return (
+    <ButtonContainer onClick={onClick} type={type}>
+      {children}
+    </ButtonContainer>
+  );
 };
 
 export default Button;

--- a/components/button/GradientButton.tsx
+++ b/components/button/GradientButton.tsx
@@ -1,22 +1,6 @@
-import { ReactNode } from "react";
+import { ComponentProps } from "react";
 import { GradientButtonContainer } from "./buttonStyled";
-
-interface ButtonProps {
-  children: ReactNode;
-  onClick?: (e: React.MouseEvent) => void;
-  type?: "submit" | "button";
-}
-
-const GradientButton = ({
-  children,
-  onClick,
-  type = "button",
-}: ButtonProps) => {
-  return (
-    <GradientButtonContainer onClick={onClick} type={type}>
-      {children}
-    </GradientButtonContainer>
-  );
-};
-
-export default GradientButton;
+export type GradientButtonProps = ComponentProps<
+  typeof GradientButtonContainer
+>;
+export default GradientButtonContainer;

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -13,7 +13,7 @@ import Image from "next/image";
 import { calculateTimeElapse } from "@/utils/utility";
 import Link from "next/link";
 import CardOptionMenu from "./CardOptionMenu";
-import { DeleteModalItem } from "@/pages/folder/[id]";
+import { DeleteModalItem } from "../folder/FolderLayout";
 
 interface CardProps {
   cardData: any;

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -13,7 +13,7 @@ import Image from "next/image";
 import { calculateTimeElapse } from "@/utils/utility";
 import Link from "next/link";
 import CardOptionMenu from "./CardOptionMenu";
-import { DeleteModalItem } from "@/pages/folder";
+import { DeleteModalItem } from "@/pages/folder/[id]";
 
 interface CardProps {
   cardData: any;

--- a/components/card/CardOptionMenu.tsx
+++ b/components/card/CardOptionMenu.tsx
@@ -1,4 +1,4 @@
-import { DeleteModalItem } from "@/pages/folder";
+import { DeleteModalItem } from "@/pages/folder/[id]";
 import { OptionMenuContainer } from "./cardStyled";
 
 interface CardOptionMenuProps {

--- a/components/card/CardOptionMenu.tsx
+++ b/components/card/CardOptionMenu.tsx
@@ -1,4 +1,4 @@
-import { DeleteModalItem } from "@/pages/folder/[id]";
+import { DeleteModalItem } from "../folder/FolderLayout";
 import { OptionMenuContainer } from "./cardStyled";
 
 interface CardOptionMenuProps {

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import Image from "next/image";
 import request from "@/lib/axios";
-import Button from "@/components/button/Button";
 import { ApiMapper } from "@/lib/apiMapper";
 import { HeaderContainer, ProfileContainer } from "./headerStyled";
 import GradientButton from "../button/GradientButton";

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -24,10 +24,13 @@ const Header = () => {
     id: null,
     image_source: "",
   });
+  const [accessToken, setAccessToken] = useState("");
 
   const handleProfile = useCallback(async () => {
     try {
-      const result = await request.get(`${ApiMapper.user.get.GET_USERS}/1`);
+      const result = await request.get(`${ApiMapper.user.get.GET_USERS}`, {
+        type: "auth",
+      });
       if (result.status === 200) {
         const { data } = result;
         setUserData(data.data[0]);
@@ -40,20 +43,27 @@ const Header = () => {
   }, []);
 
   useEffect(() => {
-    handleProfile();
-  }, [handleProfile]);
+    if (accessToken) {
+      handleProfile();
+    }
+  }, [handleProfile, accessToken]);
 
   const handleLoginBtn = () => {
     router.push("/signin");
   };
 
   useEffect(() => {
-    if (pathname === "/folder") {
+    if (pathname.includes("/folder")) {
       setIsFixed(false);
       return;
     }
     setIsFixed(true);
   }, [pathname]);
+
+  useEffect(() => {
+    const token = localStorage.getItem("accessToken");
+    if (token) setAccessToken(token);
+  }, []);
 
   return (
     <HeaderContainer $isFixed={isFixed}>
@@ -68,7 +78,7 @@ const Header = () => {
           onClick={() => router.push("/")}
         />
 
-        {userData.email ? (
+        {userData.image_source ? (
           <ProfileContainer>
             <Image
               src={userData.image_source}

--- a/components/folder/FolderLayout.tsx
+++ b/components/folder/FolderLayout.tsx
@@ -349,7 +349,10 @@ const FolderLayout = ({ cardData, selectedFolderData }: FolderLayoutProps) => {
           <AddToFolderModal
             folderData={folderData}
             link={addToFolderItem}
-            selectedFolderItem={selectedFolder}
+            selectedFolderItem={{
+              id: selectedFolder,
+              title: selectedFolderName,
+            }}
           />
         </ModalLayout>
       )}

--- a/components/folder/FolderLayout.tsx
+++ b/components/folder/FolderLayout.tsx
@@ -110,7 +110,7 @@ const FolderLayout = ({ cardData, selectedFolderData }: FolderLayoutProps) => {
 
   const handleFolder = useCallback(async () => {
     try {
-      const result = await request.get(ApiMapper.folder.get.GET_FOLDER, {
+      const result = await request.get(ApiMapper.folder.get.GET_FOLDERS, {
         path: { userId: 1 },
       });
 

--- a/components/folder/FolderLayout.tsx
+++ b/components/folder/FolderLayout.tsx
@@ -17,7 +17,7 @@ import DeleteIcon from "@/public/assets/folder/img_deleteIcon.png";
 
 import { ContentContainer, CardContainer } from "@/styles/sharedStyled";
 import AddFloatingButton from "@/components/button/AddFloatingButton";
-import { modalState } from "../recoil/modal";
+import { modalState } from "../../recoil/modal";
 import { useRecoilState } from "recoil";
 import AddToFolderModal from "@/components/modal/addToFolderModal/AddToFolderModal";
 import ModalLayout from "@/components/modal/ModalLayout";
@@ -31,6 +31,8 @@ import { ApiMapper } from "@/lib/apiMapper";
 import DeleteModal from "@/components/modal/DeleteModal";
 import EnterModal from "@/components/modal/EnterModal";
 import GradientButton from "@/components/button/GradientButton";
+import { useRouter } from "next/router";
+import { GetLinkResponse } from "@/lib/api/folder";
 
 const LinkToolArr = [
   {
@@ -80,13 +82,15 @@ const StateObj: StateObj = {
   linkDelete: "링크 삭제",
 };
 
-const Folder = () => {
-  const [cardData, setCardData] = useState([]);
+interface FolderLayoutProps {
+  cardData: GetLinkResponse[];
+  selectedFolderData: number;
+}
+
+const FolderLayout = ({ cardData, selectedFolderData }: FolderLayoutProps) => {
+  const router = useRouter();
   const [folderData, setFolderData] = useState<FolderData[]>([]);
-  const [selectedFolder, setSelectedFolder] = useState<SelectedFolder>({
-    id: 1,
-    title: "전체",
-  });
+  const [selectedFolder, setSelectedFolder] = useState(selectedFolderData);
 
   const [link, setLink] = useState("");
   const [searchLinkValue, setSearchLinkValue] = useState("");
@@ -102,6 +106,7 @@ const Folder = () => {
     id: 0,
   });
   const [addToFolderItem, setAddToFolderItem] = useState("");
+  const [selectedFolderName, setSelectedFolderName] = useState("전체");
 
   const handleFolder = useCallback(async () => {
     try {
@@ -124,34 +129,6 @@ const Folder = () => {
   useEffect(() => {
     handleFolder();
   }, [handleFolder]);
-
-  const handleLinks = useCallback(async () => {
-    try {
-      const folderId = selectedFolder.id;
-      const query = folderId !== 1 ? { folderId: folderId } : "";
-
-      const result = await request.get(ApiMapper.link.get.GET_LINK, {
-        path: {
-          userId: 1,
-        },
-        query: query,
-      });
-
-      if (result.status === 200) {
-        const { data } = result;
-        setCardData(data.data);
-        return;
-      }
-
-      throw new Error();
-    } catch (e) {
-      alert("문제가 발생했습니다. 잠시후 다시 시도해주세요.");
-    }
-  }, [selectedFolder]);
-
-  useEffect(() => {
-    handleLinks();
-  }, [handleLinks]);
 
   const handleAddToFolderModal = (content: string) => {
     setAddToFolderItem(content);
@@ -208,6 +185,12 @@ const Folder = () => {
     }
   }, [modalOpened]);
 
+  useEffect(() => {
+    const folderName = folderData.filter((e) => e.id === selectedFolder)[0]
+      ?.name;
+    setSelectedFolderName(folderName);
+  }, [folderData, selectedFolder]);
+
   return (
     <>
       <Wrapper>
@@ -256,13 +239,11 @@ const Folder = () => {
             <FolderContainer>
               <div className="folderBtnContainer">
                 <FolderBtnItemContainer
-                  $isSelected={selectedFolder.id === 1}
-                  onClick={() =>
-                    setSelectedFolder({
-                      id: 1,
-                      title: "전체",
-                    })
-                  }
+                  $isSelected={selectedFolder === 1}
+                  onClick={() => {
+                    router.push("/folder");
+                    setSelectedFolder(1);
+                  }}
                 >
                   전체
                 </FolderBtnItemContainer>
@@ -271,13 +252,11 @@ const Folder = () => {
                   return (
                     <FolderBtnItemContainer
                       key={e.id}
-                      $isSelected={e.id === selectedFolder.id}
-                      onClick={() =>
-                        setSelectedFolder({
-                          id: e.id,
-                          title: e.name,
-                        })
-                      }
+                      $isSelected={e.id === selectedFolder}
+                      onClick={() => {
+                        router.push(`/folder/${e.id}`);
+                        setSelectedFolder(e.id);
+                      }}
                     >
                       {e.name}
                     </FolderBtnItemContainer>
@@ -302,12 +281,15 @@ const Folder = () => {
               </div>
             </FolderContainer>
 
-            {cardData.length > 0 ? (
+            {cardData?.length > 0 ? (
               <>
                 <LinkHeaderContainer>
-                  <div className="linkTitle">{selectedFolder.title}</div>
+                  <div className="linkTitle">
+                    {folderData.filter((e) => e.id === selectedFolder)[0]
+                      ?.name || "전체"}
+                  </div>
 
-                  <LinkToolContainer $display={selectedFolder.id === 1}>
+                  <LinkToolContainer $display={selectedFolder === 1}>
                     {LinkToolArr.map((e, index) => {
                       return (
                         <div
@@ -319,10 +301,16 @@ const Folder = () => {
                               return;
                             }
                             if (e.state === "folderDelete") {
-                              handleDeleteModal("folderDelete", selectedFolder);
+                              handleDeleteModal("folderDelete", {
+                                id: selectedFolder,
+                                title: selectedFolderName,
+                              });
                               return;
                             }
-                            handleEnterMoal(e.state, selectedFolder);
+                            handleEnterMoal(e.state, {
+                              id: selectedFolder,
+                              title: selectedFolderName,
+                            });
                           }}
                         >
                           <Image src={e.src} alt={e.title} />
@@ -372,7 +360,9 @@ const Folder = () => {
       )}
       {modalOpened.shareFolderModal.display && (
         <ModalLayout>
-          <ShareFolderModal content={selectedFolder} />
+          <ShareFolderModal
+            content={{ id: selectedFolder, title: selectedFolderName }}
+          />
         </ModalLayout>
       )}
       {modalOpened.deleteModal.display && (
@@ -384,4 +374,4 @@ const Folder = () => {
   );
 };
 
-export default Folder;
+export default FolderLayout;

--- a/components/input/EmailInput.tsx
+++ b/components/input/EmailInput.tsx
@@ -26,9 +26,7 @@ const EmailInput = ({ name, control }: EmailInputProps) => {
       <label htmlFor="email">이메일</label>
       <div className="inputBox">
         <Input
-          aria-invalid={
-            error ? "1px solid var(--red)" : "1px solid var(--gray20)"
-          }
+          $isError={error !== undefined}
           type="text"
           id="email"
           placeholder="이메일을 입력해주세요."
@@ -38,13 +36,7 @@ const EmailInput = ({ name, control }: EmailInputProps) => {
           name={field.name}
         />
       </div>
-      {error?.type === "required" && (
-        <div className="errorMsg">{error.message}</div>
-      )}
-      {error?.type === "pattern" && (
-        <div className="errorMsg">{error.message}</div>
-      )}
-      {error?.type === "validate" && (
+      {error && ["required", "pattern", "validate"].includes(error?.type) && (
         <div className="errorMsg">{error.message}</div>
       )}
     </InputContainer>

--- a/components/input/PasswordInput.tsx
+++ b/components/input/PasswordInput.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import EyeOn from "@/public/assets/common/img_eyeOn.png";
 import EyeOff from "@/public/assets/common/img_eyeOff.png";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Input, InputContainer } from "./userInputStyled";
 import { Control, FieldPath, useController } from "react-hook-form";
 
@@ -37,9 +37,7 @@ const PasswordInput = (props: UserInputProps) => {
       <label htmlFor={label}>{obj[label]}</label>
       <div className="inputBox">
         <Input
-          aria-invalid={
-            error ? "1px solid var(--red)" : "1px solid var(--gray20)"
-          }
+          $isError={error !== undefined}
           type={isPasswordVisible ? "text" : "password"}
           id={label}
           placeholder={placeholder}
@@ -57,13 +55,7 @@ const PasswordInput = (props: UserInputProps) => {
           onClick={() => setIsPasswordVisible(!isPasswordVisible)}
         />
       </div>
-      {error?.type === "required" && (
-        <div className="errorMsg">{error.message}</div>
-      )}
-      {error?.type === "validate" && (
-        <div className="errorMsg">{error.message}</div>
-      )}
-      {error?.type === "pattern" && (
+      {error && ["required", "pattern", "validate"].includes(error?.type) && (
         <div className="errorMsg">{error.message}</div>
       )}
     </InputContainer>

--- a/components/input/userInputStyled.ts
+++ b/components/input/userInputStyled.ts
@@ -1,3 +1,4 @@
+import { FieldError } from "react-hook-form";
 import styled from "styled-components";
 
 export const InputContainer = styled.div`
@@ -30,12 +31,13 @@ export const InputContainer = styled.div`
   }
 `;
 
-export const Input = styled.input<{ "aria-invalid": string }>`
+export const Input = styled.input<{ $isError: boolean }>`
   box-sizing: border-box;
   border-radius: 0.8rem;
   padding: 1.8rem 1.5rem;
   background: var(--white);
-  border: ${(props) => props["aria-invalid"]};
+  border: ${(props) =>
+    props.$isError ? "1px solid var(--red)" : "1px solid var(--gray20)"};
   width: 40rem;
   height: 6rem;
   color: var(--gray100);

--- a/components/modal/addToFolderModal/AddToFolderModal.tsx
+++ b/components/modal/addToFolderModal/AddToFolderModal.tsx
@@ -5,9 +5,9 @@ import CloseIcon from "@/public/assets/modal/img_closeIcon.png";
 import CheckIcon from "@/public/assets/modal/img_checkIcon.png";
 import Image from "next/image";
 import { ModalMainContainer } from "../ModalStyledComponents";
-import { FolderData, SelectedFolder } from "@/pages/folder/[id]";
 import { FolderContainer } from "./addToFolderModalStyled";
 import GradientButton from "@/components/button/GradientButton";
+import { FolderData, SelectedFolder } from "@/components/folder/FolderLayout";
 
 interface AddToFolderModalProp {
   folderData: FolderData[];

--- a/components/modal/addToFolderModal/AddToFolderModal.tsx
+++ b/components/modal/addToFolderModal/AddToFolderModal.tsx
@@ -5,7 +5,7 @@ import CloseIcon from "@/public/assets/modal/img_closeIcon.png";
 import CheckIcon from "@/public/assets/modal/img_checkIcon.png";
 import Image from "next/image";
 import { ModalMainContainer } from "../ModalStyledComponents";
-import { FolderData, SelectedFolder } from "@/pages/folder";
+import { FolderData, SelectedFolder } from "@/pages/folder/[id]";
 import { FolderContainer } from "./addToFolderModalStyled";
 import GradientButton from "@/components/button/GradientButton";
 

--- a/lib/api/auth.ts/auth.ts
+++ b/lib/api/auth.ts/auth.ts
@@ -1,0 +1,47 @@
+import { ApiMapper } from "@/lib/apiMapper";
+import request from "@/lib/axios";
+
+interface UserData {
+  email: string;
+  password: string;
+}
+
+interface SaveTokenProps {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export const signin = async (data: UserData) => {
+  try {
+    const response = await request.post(`${ApiMapper.auth.post.SIGN_IN}`, data);
+
+    if (response.status === 200) {
+      const { data } = response;
+      saveToken(data.data);
+      return true;
+    }
+    throw new Error();
+  } catch (e) {
+    return false;
+  }
+};
+
+export const signup = async (data: UserData) => {
+  try {
+    const response = await request.post(`${ApiMapper.auth.post.SIGN_UP}`, data);
+
+    if (response.status === 200) {
+      const { data } = response;
+      saveToken(data.data);
+      return true;
+    }
+    throw new Error();
+  } catch (e) {
+    return false;
+  }
+};
+
+const saveToken = ({ accessToken, refreshToken }: SaveTokenProps) => {
+  localStorage.setItem("accessToken", accessToken);
+  localStorage.setItem("refreshToken", refreshToken);
+};

--- a/lib/api/folder/index.ts
+++ b/lib/api/folder/index.ts
@@ -1,0 +1,38 @@
+import { ApiMapper } from "@/lib/apiMapper";
+import request from "@/lib/axios";
+
+interface GetLinksProps {
+  id: number | null;
+}
+
+export interface GetLinkResponse {
+  created_at: string;
+  description: string;
+  folder_id: number;
+  id: number;
+  image_source: string;
+  title: string;
+  url: string;
+  updated_at: string;
+}
+
+export const handleGetLinks = async ({ id }: GetLinksProps) => {
+  try {
+    const query = id ? { folderId: id } : "";
+
+    const result = await request.get(ApiMapper.link.get.GET_LINK, {
+      query: query,
+      type: "auth",
+    });
+
+    if (result.status === 200) {
+      const res: GetLinkResponse[] = result.data.data.folder;
+      return res;
+    }
+
+    throw new Error();
+  } catch (e) {
+    alert("문제가 발생했습니다. 잠시후 다시 시도해주세요.");
+    return [];
+  }
+};

--- a/lib/apiMapper.ts
+++ b/lib/apiMapper.ts
@@ -1,16 +1,10 @@
 const URL_PATH = {
-  SAMPLE_CONTROLLER: "/api/sample",
   USER_CONTROLLER: "/api/users",
   LINK_CONTROLLER: "/api/links",
+  FOLDER_CONTROLLER: "/api/folders",
 };
 
 export const ApiMapper = {
-  sample: {
-    get: {
-      GET_FOLDER: `${URL_PATH.SAMPLE_CONTROLLER}/folder`,
-      GET_USER: `${URL_PATH.SAMPLE_CONTROLLER}/user`,
-    },
-  },
   user: {
     get: {
       GET_USERS: `${URL_PATH.USER_CONTROLLER}`,
@@ -21,12 +15,14 @@ export const ApiMapper = {
   },
   folder: {
     get: {
-      GET_FOLDER: `${URL_PATH.USER_CONTROLLER}/:userId/folders`,
+      GET_FOLDERS: `${URL_PATH.USER_CONTROLLER}/:userId/folders`,
+      GET_FOLDER: `${URL_PATH.FOLDER_CONTROLLER}`,
     },
   },
   link: {
     get: {
       GET_LINK: `${URL_PATH.LINK_CONTROLLER}`,
+      GET_LINKS: `${URL_PATH.USER_CONTROLLER}/:userId/links`,
     },
   },
   auth: {

--- a/lib/apiMapper.ts
+++ b/lib/apiMapper.ts
@@ -1,6 +1,7 @@
 const URL_PATH = {
   SAMPLE_CONTROLLER: "/api/sample",
   USER_CONTROLLER: "/api/users",
+  LINK_CONTROLLER: "/api/links",
 };
 
 export const ApiMapper = {
@@ -25,7 +26,7 @@ export const ApiMapper = {
   },
   link: {
     get: {
-      GET_LINK: `${URL_PATH.USER_CONTROLLER}/:userId/links`,
+      GET_LINK: `${URL_PATH.LINK_CONTROLLER}`,
     },
   },
   auth: {

--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -5,6 +5,7 @@ declare module "axios" {
   export interface AxiosRequestConfig {
     path?: {};
     query?: {};
+    type?: "auth" | "default";
   }
 }
 
@@ -18,6 +19,9 @@ const request = axios.create({
 
 request.interceptors.request.use(
   (config) => {
+    const { type = "default" } = config;
+    const accessToken = localStorage.getItem("accessToken");
+
     if (config.path && config.url) {
       for (const [key, value] of Object.entries(config.path)) {
         config.url = config.url.replace(`:${key}`, String(value));
@@ -27,6 +31,12 @@ request.interceptors.request.use(
     if (!isEmpty(config.query)) {
       const query = new URLSearchParams(config.query).toString();
       config.url += "?" + query;
+    }
+
+    if (type === "auth") {
+      if (accessToken) {
+        config.headers["Authorization"] = `Bearer ${accessToken}`;
+      }
     }
 
     return config;

--- a/next.config.js
+++ b/next.config.js
@@ -51,6 +51,54 @@ const nextConfig = {
         protocol: "https",
         hostname: "codeit.kr",
       },
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+      },
+      {
+        protocol: "https",
+        hostname: "www.baskinrobbins.co.kr",
+      },
+      {
+        protocol: "https",
+        hostname: "akamai.pizzahut.co.kr",
+      },
+      {
+        protocol: "http",
+        hostname: "www.istarbucks.co.kr",
+      },
+      {
+        protocol: "http",
+        hostname: "www.coffeebeankorea.com",
+      },
+      {
+        protocol: "https",
+        hostname: "cdn.goob-ne.com",
+      },
+      {
+        protocol: "https",
+        hostname: "resources.jetbrains.com",
+      },
+      {
+        protocol: "https",
+        hostname: "react.dev",
+      },
+      {
+        protocol: "http",
+        hostname: "www.rust-lang.org",
+      },
+      {
+        protocol: "https",
+        hostname: "spring.io",
+      },
+      {
+        protocol: "https",
+        hostname: "www.rust-lang.org",
+      },
+      {
+        protocol: "https",
+        hostname: "spring.io",
+      },
     ],
   },
 };

--- a/pages/folder/[id].tsx
+++ b/pages/folder/[id].tsx
@@ -7,6 +7,7 @@ const FolderDetail = () => {
   const router = useRouter();
   const [cardData, setCardData] = useState<GetLinkResponse[]>([]);
   const { id } = router.query;
+  const [isAccessToken, setIsAccessToken] = useState(false);
 
   const handleLinks = useCallback(async () => {
     const res = await handleGetLinks({ id: Number(id) });
@@ -14,10 +15,21 @@ const FolderDetail = () => {
   }, [id]);
 
   useEffect(() => {
+    if (!localStorage.getItem("accessToken")) {
+      router.push("/signin");
+      return;
+    }
+    setIsAccessToken(true);
     handleLinks();
-  }, [handleLinks]);
+  }, [handleLinks, router]);
 
-  return <FolderLayout selectedFolderData={Number(id)} cardData={cardData} />;
+  return (
+    <>
+      {isAccessToken && (
+        <FolderLayout selectedFolderData={Number(id)} cardData={cardData} />
+      )}
+    </>
+  );
 };
 
 export default FolderDetail;

--- a/pages/folder/[id].tsx
+++ b/pages/folder/[id].tsx
@@ -1,0 +1,23 @@
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import FolderLayout from "@/components/folder/FolderLayout";
+import { GetLinkResponse, handleGetLinks } from "@/lib/api/folder";
+
+const FolderDetail = () => {
+  const router = useRouter();
+  const [cardData, setCardData] = useState<GetLinkResponse[]>([]);
+  const { id } = router.query;
+
+  const handleLinks = useCallback(async () => {
+    const res = await handleGetLinks({ id: Number(id) });
+    setCardData(res);
+  }, [id]);
+
+  useEffect(() => {
+    handleLinks();
+  }, [handleLinks]);
+
+  return <FolderLayout selectedFolderData={Number(id)} cardData={cardData} />;
+};
+
+export default FolderDetail;

--- a/pages/folder/index.tsx
+++ b/pages/folder/index.tsx
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import FolderLayout from "@/components/folder/FolderLayout";
 import { GetLinkResponse, handleGetLinks } from "@/lib/api/folder";
+import { useRouter } from "next/router";
 
 const Folder = () => {
+  const router = useRouter();
   const [cardData, setCardData] = useState<GetLinkResponse[]>([]);
+  const [isAccessToken, setIsAccessToken] = useState(false);
 
   const handleLinks = useCallback(async () => {
     const res = await handleGetLinks({ id: null });
@@ -11,10 +14,21 @@ const Folder = () => {
   }, []);
 
   useEffect(() => {
+    if (!localStorage.getItem("accessToken")) {
+      router.push("/signin");
+      return;
+    }
+    setIsAccessToken(true);
     handleLinks();
-  }, [handleLinks]);
+  }, [handleLinks, router]);
 
-  return <FolderLayout selectedFolderData={1} cardData={cardData} />;
+  return (
+    <>
+      {isAccessToken && (
+        <FolderLayout selectedFolderData={1} cardData={cardData} />
+      )}
+    </>
+  );
 };
 
 export default Folder;

--- a/pages/folder/index.tsx
+++ b/pages/folder/index.tsx
@@ -1,0 +1,20 @@
+import { useCallback, useEffect, useState } from "react";
+import FolderLayout from "@/components/folder/FolderLayout";
+import { GetLinkResponse, handleGetLinks } from "@/lib/api/folder";
+
+const Folder = () => {
+  const [cardData, setCardData] = useState<GetLinkResponse[]>([]);
+
+  const handleLinks = useCallback(async () => {
+    const res = await handleGetLinks({ id: null });
+    setCardData(res);
+  }, []);
+
+  useEffect(() => {
+    handleLinks();
+  }, [handleLinks]);
+
+  return <FolderLayout selectedFolderData={1} cardData={cardData} />;
+};
+
+export default Folder;

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -2,8 +2,7 @@ import GradientButton from "@/components/button/GradientButton";
 import EmailInput from "@/components/input/EmailInput";
 import PasswordInput from "@/components/input/PasswordInput";
 import UserLayout from "@/components/user/UserLayout";
-import { ApiMapper } from "@/lib/apiMapper";
-import request from "@/lib/axios";
+import { signin } from "@/lib/api/auth.ts/auth";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
@@ -31,13 +30,9 @@ const Signin = () => {
 
   const handleSignin = async (data: any) => {
     try {
-      const result = await request.post(`${ApiMapper.auth.post.SIGN_IN}`, data);
-
-      if (result.status === 200) {
-        const { data } = result;
-        localStorage.setItem("accessToken", data.data.accessToken);
+      const result = await signin(data);
+      if (result) {
         router.push("/folder");
-        return;
       }
       throw new Error();
     } catch (e) {

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { userData } from "./signin";
+import { signup } from "@/lib/api/auth.ts/auth";
 
 interface SignupData extends userData {
   passwordConfirm: string;
@@ -92,11 +93,9 @@ const Signup = () => {
     }
 
     try {
-      const result = await request.post(`${ApiMapper.auth.post.SIGN_UP}`, data);
+      const result = await signup(data);
 
-      if (result.status === 200) {
-        const { data } = result;
-        localStorage.setItem("accessToken", data.data.accessToken);
+      if (result) {
         router.push("/folder");
         return;
       }

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -143,7 +143,7 @@ const Signup = () => {
             control={control}
             name={"passwordConfirm"}
           />
-          <GradientButton type={"submit"}>회원가입</GradientButton>
+          <GradientButton type="submit">회원가입</GradientButton>
         </form>
       }
     />

--- a/styles/sharedStyled.ts
+++ b/styles/sharedStyled.ts
@@ -39,6 +39,26 @@ export const ContentContainer = styled.div<{ $isFolder: boolean }>`
 export const FolderContentContainer = styled(ContentContainer)`
   margin: 4rem auto 6rem;
   gap: 4rem;
+  min-width: 106rem;
+  @media all and (${device.tablet}) {
+    min-width: calc(100vw - 6.4rem);
+  }
+  @media all and (${device.mobile}) {
+    min-width: calc(100vw - 6.4rem);
+  }
+
+  .noLinkContainer {
+    color: #000;
+    width: 100%;
+    padding: 4.1rem 0 3.9rem;
+    text-align: center;
+    font-size: 1.6rem;
+    font-weight: 400;
+    line-height: 2.4rem;
+    @media all and (${device.mobile}) {
+      font-size: 1.4rem;
+    }
+  }
 `;
 
 export const CardContainer = styled.div`


### PR DESCRIPTION
## 요구사항

### 기본
- [x] [링크 공유 페이지] 링크 공유 페이지의 url path를 ‘/shared’에서 ‘/shared/{folderId}’로 변경했나요?
- [x] [링크 공유 페이지] 폴더의 정보는 ‘/api/folders/{folderId}’, 폴더 소유자의 정보는 ‘/api/users/{userId}’를 활용했나요?
- [x] [링크 공유 페이지] 링크 공유 페이지에서 폴더의 링크 데이터는 ‘/api/users/{userId}/links?folderId={folderId}’를 사용했나요?
- [x] [폴더 페이지] 폴더 페이지에서 유저가 access token이 없는 경우 ‘/signin’페이지로 이동하나요?
- [x] [폴더 페이지] 폴더 페이지의 url path가 ‘/folder’일 경우 폴더 목록에서 “전체” 가 선택되어 있고, ‘/folder/{folderId}’일 경우 폴더 목록에서 {folderId} 에 해당하는 폴더가 선택되어 있고 폴더에 있는 링크들을 볼 수 있나요?
- [x] [폴더 페이지] 폴더 페이지에서 현재 유저의 폴더 목록 데이터를 받아올 때 ‘/api/folders’를 활용했나요?
- [x] [폴더 페이지] 폴더 페이지에서 전체 링크 데이터를 받아올 때 ‘/api/links’, 특정 폴더의 링크를 받아올 때 ‘/api/links?folderId=1’를 활용했나요?
- [x] [상단 네비게이션] 유효한 access token이 있는 경우 ‘/api/users’로 현재 로그인한 유저 정보를 받아 상단 네비게이션 유저 프로필을 보여주나요?

### 심화

- [x] 리퀘스트 헤더에 인증 토큰을 첨부할 때 axios interceptors 또는 이와 유사한 기능을 활용 했나요?

## 주요 변경사항

- 로그인 없이 folder 페이지 접근 불가
- signin, signup관련 auth로 관리
- accessToken 실어서 api 요청 추가
- folder, shared [id] 라우팅

## 스크린샷

https://github.com/codeit-bootcamp-frontend/1-Weekly-Mission/assets/77039033/c3d8a3ed-c4fc-4d4d-bb02-c63114622d97


https://github.com/codeit-bootcamp-frontend/1-Weekly-Mission/assets/77039033/46920c55-c03f-4440-a926-5b3ed50410a6


## 멘토에게

- 인증관련해서 어떤식으로 처리하면 좋을지 잘 모르겠습니다. 
