### PR TITLE
[홍재원] week15

### DIFF
--- a/src/api/axiosInstance.tsx
+++ b/src/api/axiosInstance.tsx
@@ -10,9 +10,11 @@ export const axiosInstance = axios.create({
 
 axiosInstance.interceptors.request.use((config) => {
   if (!config.headers) return config;
-  const accessToken = localStorage.getItem("accessToken") || "";
-  if (accessToken && config.headers) {
-    config.headers["Authorization"] = accessToken;
+  if (typeof window !== "undefined") {
+    const accessToken = localStorage.getItem("accessToken");
+    if (accessToken && config.headers) {
+      config.headers["Authorization"] = accessToken;
+    }
   }
   return config;
 });

--- a/src/api/axiosInstance.tsx
+++ b/src/api/axiosInstance.tsx
@@ -2,4 +2,5 @@ import axios from "axios";
 
 export const axiosInstance = axios.create({
   baseURL: "https://bootcamp-api.codeit.kr/api/",
+  withCredentials: true,
 });

--- a/src/api/axiosInstance.tsx
+++ b/src/api/axiosInstance.tsx
@@ -4,6 +4,45 @@ export const axiosInstance = axios.create({
   baseURL: "https://bootcamp-api.codeit.kr/api/",
   headers: {
     "Content-Type": "application/json",
+    withCredentials: true,
   },
-  withCredentials: true,
 });
+
+axiosInstance.interceptors.request.use((config) => {
+  if (!config.headers) return config;
+  const accessToken = localStorage.getItem("accessToken") || "";
+  if (accessToken && config.headers) {
+    config.headers["Authorization"] = accessToken;
+  }
+  return config;
+});
+
+axiosInstance.interceptors.response.use(
+  (res) => {
+    return res;
+  },
+  async (error) => {
+    if (error.config && error.response && error.response.status === 401) {
+      error.config._retry = true;
+      const refreshtoken = localStorage.getItem("refreshToken");
+      error.config.headers.RefreshToken = `${refreshtoken}`;
+      return axios
+        .get(`${process.env.NEXT_PUBLIC_API_URL}/auth/me`, {
+          headers: {
+            RefreshToken: `${refreshtoken}`,
+            "Content-Type": "application/json",
+            withCredentials: true,
+          },
+        })
+        .then(async (res) => {
+          if (res.status === 200 && res.data.accessToken) {
+            localStorage.setItem("accessToken", res.data.accessToken);
+            const accesstoken = localStorage.getItem("accessToken");
+            error.config.headers["Authorization"] = `${accesstoken}`;
+            return axiosInstance(error.config);
+          }
+        });
+    }
+    return Promise.reject(error);
+  },
+);

--- a/src/api/axiosInstance.tsx
+++ b/src/api/axiosInstance.tsx
@@ -2,5 +2,8 @@ import axios from "axios";
 
 export const axiosInstance = axios.create({
   baseURL: "https://bootcamp-api.codeit.kr/api/",
+  headers: {
+    "Content-Type": "application/json",
+  },
   withCredentials: true,
 });

--- a/src/api/getAllCards.tsx
+++ b/src/api/getAllCards.tsx
@@ -1,16 +1,14 @@
-import { CardInterface } from "@/types";
-import { USER_ID } from "./constants";
 import { axiosInstance } from "./axiosInstance";
 
-export default async function getAllCards(id = "") {
-  let url = `${USER_ID}/links?`;
+export default async function getAllCards(userId = "", folderId = "") {
+  let url = `${userId}/links?`;
   const searchUrl = new URLSearchParams();
-  if (id !== "") {
-    searchUrl.append("folderId", id);
+  if (folderId !== "") {
+    searchUrl.append("folderId", folderId);
     url += searchUrl.toString();
   }
-
+  console.log(url);
   const response = await axiosInstance.get(`${url}`);
-  const data: CardInterface[] = response?.data?.data;
-  return data;
+  const data = response?.data?.data;
+  return data?.folder;
 }

--- a/src/api/getFolderList.tsx
+++ b/src/api/getFolderList.tsx
@@ -1,7 +1,6 @@
 import { axiosInstance } from "./axiosInstance";
-import { USER_ID } from "./constants";
 
-export default async function getFolderList() {
-  const response = await axiosInstance.get(`${USER_ID}/folders`);
+export default async function getFolderList(userId = "") {
+  const response = await axiosInstance.get(`${userId}/folders`);
   return response?.data;
 }

--- a/src/api/getNewToken.tsx
+++ b/src/api/getNewToken.tsx
@@ -1,0 +1,10 @@
+import { axiosInstance } from "./axiosInstance";
+
+export default async function getNewToken(refreshToken = "") {
+  if (!refreshToken) return;
+
+  const response = await axiosInstance.post("/refresh-token", {
+    refresh_token: refreshToken,
+  });
+  return response?.data;
+}

--- a/src/api/getSignUp.tsx
+++ b/src/api/getSignUp.tsx
@@ -1,16 +1,11 @@
-// BUG - 왜 instance 쓰면 안됨????
 import { axiosInstance } from "./axiosInstance";
-import axios from "axios";
 
 export default async function getSignUp(email = "", password = "") {
   try {
-    const response = await axios.post(
-      "https://bootcamp-api.codeit.kr/api/sign-up",
-      {
-        email: email,
-        password: password,
-      },
-    );
+    const response = await axiosInstance.post("/sign-up", {
+      email: email,
+      password: password,
+    });
     return response.data;
   } catch (e) {
     return;

--- a/src/api/getSignUp.tsx
+++ b/src/api/getSignUp.tsx
@@ -1,11 +1,16 @@
+// BUG - 왜 instance 쓰면 안됨????
 import { axiosInstance } from "./axiosInstance";
+import axios from "axios";
 
 export default async function getSignUp(email = "", password = "") {
   try {
-    const response = await axiosInstance.post(`sign-up`, {
-      email: email,
-      password: password,
-    });
+    const response = await axios.post(
+      "https://bootcamp-api.codeit.kr/api/sign-up",
+      {
+        email: email,
+        password: password,
+      },
+    );
     return response.data;
   } catch (e) {
     return;

--- a/src/api/getSignin.tsx
+++ b/src/api/getSignin.tsx
@@ -1,13 +1,19 @@
+// BUG - 왜 instance 쓰면 안됨????
+import axios from "axios";
 import { axiosInstance } from "./axiosInstance";
 
 export default async function getSignIn(email = "", password = "") {
   try {
-    const response = await axiosInstance.post(`sign-in`, {
-      email: email,
-      password: password,
-    });
+    const response = await axios.post(
+      "https://bootcamp-api.codeit.kr/api/sign-in",
+      {
+        email: email,
+        password: password,
+      },
+    );
     return response.data;
   } catch (e) {
+    console.log(e);
     return;
   }
 }

--- a/src/api/getSignin.tsx
+++ b/src/api/getSignin.tsx
@@ -1,16 +1,11 @@
-// BUG - 왜 instance 쓰면 안됨????
-import axios from "axios";
 import { axiosInstance } from "./axiosInstance";
 
 export default async function getSignIn(email = "", password = "") {
   try {
-    const response = await axios.post(
-      "https://bootcamp-api.codeit.kr/api/sign-in",
-      {
-        email: email,
-        password: password,
-      },
-    );
+    const response = await axiosInstance.post("/sign-in", {
+      email: email,
+      password: password,
+    });
     return response.data;
   } catch (e) {
     console.log(e);

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -1,6 +1,7 @@
 import getAllCards from "./getAllCards";
 import getFolderList from "./getFolderList";
 import getUser from "./getUser";
+import getNewToken from "./getNewToken";
 
 import getSharedFolder from "./getSharedFolder";
 import getSharedUser from "./getSharedUser";
@@ -12,6 +13,7 @@ import getSignUp from "./getSignUp";
 export {
   getAllCards,
   getFolderList,
+  getNewToken,
   getUser,
   getSharedFolder,
   getSharedUser,

--- a/src/components/common/Nav/Nav.tsx
+++ b/src/components/common/Nav/Nav.tsx
@@ -15,8 +15,7 @@ function Nav({ isSticky }: { isSticky?: boolean }) {
     ? { className: `${styles["sticky"]} ${styles["nav"]}` }
     : { className: `${styles["nav"]}` };
 
-  const { user: profile, logout } = useAuth();
-
+  const { user, logout } = useAuth();
   return (
     <nav {...navClassName}>
       <div className={styles["gnb"]}>
@@ -29,7 +28,7 @@ function Nav({ isSticky }: { isSticky?: boolean }) {
             alt="로고 크기"
           />
         </Link>
-        {!profile ? (
+        {user === null ? (
           <button
             className={`${styles["link-button"]} ${styles["signin-button"]}`}
           >
@@ -38,12 +37,12 @@ function Nav({ isSticky }: { isSticky?: boolean }) {
         ) : (
           <div className={styles["user-info"]}>
             <Image
-              src={profile.image_source || "/public/images/no-profile.png"}
+              src={user.image_source || "/public/images/no-profile.png"}
               alt="profile"
               width={20}
               height={20}
             />
-            <span>{profile.email}</span>
+            <span>{user.email}</span>
             <button onClick={logout}>로그아웃</button>
           </div>
         )}

--- a/src/components/common/Nav/Nav.tsx
+++ b/src/components/common/Nav/Nav.tsx
@@ -7,19 +7,15 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { UserInterface } from "@/types";
 import styles from "./Nav.module.scss";
+import { useAuth } from "@/contexts/AuthProvider";
 
-function Nav({
-  profile,
-  isSticky,
-}: {
-  profile?: UserInterface;
-  isSticky?: boolean;
-}) {
+function Nav({ isSticky }: { isSticky?: boolean }) {
   let navClassName = isSticky
     ? { className: `${styles["sticky"]} ${styles["nav"]}` }
     : { className: `${styles["nav"]}` };
+
+  const { user: profile, logout } = useAuth();
 
   return (
     <nav {...navClassName}>
@@ -37,7 +33,7 @@ function Nav({
           <button
             className={`${styles["link-button"]} ${styles["signin-button"]}`}
           >
-            <Link href="./">로그인</Link>
+            <Link href="/signin">로그인</Link>
           </button>
         ) : (
           <div className={styles["user-info"]}>
@@ -48,6 +44,7 @@ function Nav({
               height={20}
             />
             <span>{profile.email}</span>
+            <button onClick={logout}>로그아웃</button>
           </div>
         )}
       </div>

--- a/src/components/sign/SignLayout/SignLayout.tsx
+++ b/src/components/sign/SignLayout/SignLayout.tsx
@@ -5,11 +5,11 @@
 */
 
 import Link from "next/link";
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 import styles from "./SignLayout.module.scss";
 import { SnsSign } from "..";
 
-type defaultType = "signin" | "signup";
+type PageType = "signin" | "signup";
 
 const SIGNIN_TYPE = {
   type: "signin",
@@ -29,10 +29,7 @@ const SIGNUP_TYPE = {
 function SignLayout({
   type = "signin",
   children,
-}: {
-  type: defaultType;
-  children: ReactNode;
-}) {
+}: PropsWithChildren<{ type: PageType }>) {
   const pageType = type === "signin" ? SIGNIN_TYPE : SIGNUP_TYPE;
 
   return (

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -101,7 +101,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
 // 유저 인증이 필요한 페이지에선 required true 값을 주고,
 // required가 false인데 context.user 값이 없고 로딩 중이 아니라면 로그인 페이지로 이동시킨다.
-export function useAuth(required = "true") {
+export function useAuth(required = "false") {
   const context = useContext(AuthContext);
   const router = useRouter();
   if (!context) {

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -46,9 +46,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   });
 
   // 유저 데이터를 가져오는 함수.
-  /* TODO - 지금은 토큰을 request body로 보내주기 때문에 getMe 인자로 토큰을 받지만,
-    나중에 set-cookies로 토큰을 받아 브라우저가 자동으로 저장하게 된다면 해당 인자를 없애버리자.
-  */
   async function getMe() {
     setValues((prev) => ({ ...prev, isPending: true }));
     let nextUser: UserInterface;

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -16,18 +16,27 @@ import {
   useEffect,
   ReactNode,
 } from "react";
+import axios from "axios";
 import { axiosInstance } from "@/api/axiosInstance";
 import { getSignIn, getNewToken } from "@/api";
 import { useRouter } from "next/router";
 import { UserInterface } from "@/types";
 import { AxiosResponse } from "axios";
 
-export const AuthContext = createContext({
-  user: null as UserInterface | null,
-  isPending: true as boolean,
+interface INT {
+  user: null | UserInterface;
+  isPending: boolean;
+  login: any;
+  logout: any;
+}
+
+const initial: INT = {
+  user: null,
+  isPending: true,
   login: () => {},
   logout: () => {},
-});
+};
+export const AuthContext = createContext(initial);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [values, setValues] = useState<{
@@ -46,11 +55,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setValues((prev) => ({ ...prev, isPending: true }));
     let nextUser: UserInterface;
     try {
-      const res = await axiosInstance.get("/users", {
+      // const res = await axiosInstance.get("/users", {
+      // headers: { Authorization: accessToken },
+      // });
+      const res = await axios.get("https://bootcamp-api.codeit.kr/api/users", {
         headers: { Authorization: accessToken },
       });
       nextUser = res.data;
     } catch (e) {
+      console.log(e);
       if ((e as AxiosResponse<Error>)?.status === 401) {
         const {
           accessToken: newAccessToken = "",
@@ -74,8 +87,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // data 안에 accessToken과 refreshToken 이 있다.
   // 전역 변수 context.user의 값을 getMe로 업데이트해야 한다.
   async function login(email = "", password = "") {
-    const { accessToken, refreshToken } = await getSignIn(email, password);
-    await getMe(accessToken, refreshToken);
+    const { data } = await getSignIn(email, password);
+    await getMe(data.accessToken, data.refreshToken);
   }
 
   // TODO - 로그아웃 함수. 로그아웃하면 해당 유저 정보를 delete 리퀘를 보낸다. 어라 로그아웃 api 보내는 곳이 없네...

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -79,6 +79,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       user: null,
       isPending: false,
     }));
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
   }
 
   // TODO - 나중에 setting 페이지도 만들 수 있음 만들어보자.
@@ -106,9 +108,9 @@ export function useAuth(required = false) {
   useEffect(() => {
     if (
       router.route !== "/signup" &&
+      context.user === null &&
       required &&
-      !context.isPending &&
-      !context.user
+      !context.isPending
     ) {
       router.push("/signin");
     }

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -96,10 +96,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 }
 
 // 유저 인증이 필요한 페이지에선 required true 값을 주고,
-// required가 false인데 context.user 값이 없고 로딩 중이 아니라면 로그인 페이지로 이동시킨다.
+// required가 true인데 context.user 값이 없고 로딩 중이 아니라면 로그인 페이지로 이동시킨다.
 export function useAuth(required = false) {
   const context = useContext(AuthContext);
-  console.log(context);
   const router = useRouter();
   if (!context) {
     throw new Error("반드시 AuthProvider 안에서 사용해야 합니다.");
@@ -108,11 +107,12 @@ export function useAuth(required = false) {
   useEffect(() => {
     if (
       router.route !== "/signup" &&
-      context.user === null &&
+      !context.user &&
       required &&
       !context.isPending
     ) {
       router.push("/signin");
+      return;
     }
   }, [context.user, context.isPending, required]);
 

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -1,0 +1,118 @@
+/*
+  NOTE - 지금 user에 저장하는 값은 아래 형태와 같은 데이터다!!
+    {
+      "id": 25,
+      "created_at": "2023-08-31T02:18:03.139213+00:00",
+      "name": "온우림",
+      "image_source": "https://avatars.githubusercontent.com/u/75120340",
+      "email": "test@codeit.com",
+      "auth_id": "955801a8-85c5-4672-b729-612e646a640a"
+    }
+*/
+import {
+  createContext,
+  useState,
+  useContext,
+  useEffect,
+  ReactNode,
+} from "react";
+import { axiosInstance } from "@/api/axiosInstance";
+import { getSignIn, getNewToken } from "@/api";
+import { useRouter } from "next/router";
+import { UserInterface } from "@/types";
+import { AxiosResponse } from "axios";
+
+export const AuthContext = createContext({
+  user: null as UserInterface | null,
+  isPending: true as boolean,
+  login: () => {},
+  logout: () => {},
+});
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [values, setValues] = useState<{
+    user: UserInterface | null;
+    isPending: boolean;
+  }>({
+    user: null,
+    isPending: true,
+  });
+
+  // 유저 데이터를 가져오는 함수.
+  /* TODO - 지금은 토큰을 request body로 보내주기 때문에 getMe 인자로 토큰을 받지만,
+    나중에 set-cookies로 토큰을 받아 브라우저가 자동으로 저장하게 된다면 해당 인자를 없애버리자.
+  */
+  async function getMe(accessToken = "", refreshToken = "") {
+    setValues((prev) => ({ ...prev, isPending: true }));
+    let nextUser: UserInterface;
+    try {
+      const res = await axiosInstance.get("/users", {
+        headers: { Authorization: accessToken },
+      });
+      nextUser = res.data;
+    } catch (e) {
+      if ((e as AxiosResponse<Error>)?.status === 401) {
+        const {
+          accessToken: newAccessToken = "",
+          refreshToken: newRefreshToken = "",
+        } = await getNewToken(refreshToken);
+        const res = await axiosInstance.get("/users", {
+          headers: { Authorization: newAccessToken },
+        });
+        nextUser = res.data;
+      }
+    } finally {
+      setValues((prev) => ({
+        ...prev,
+        user: nextUser,
+        isPending: false,
+      }));
+    }
+  }
+
+  // 로그인 함수. 로그인하면 해당 유저 정보를 post 리퀘를 보낸다.
+  // data 안에 accessToken과 refreshToken 이 있다.
+  // 전역 변수 context.user의 값을 getMe로 업데이트해야 한다.
+  async function login(email = "", password = "") {
+    const { accessToken, refreshToken } = await getSignIn(email, password);
+    await getMe(accessToken, refreshToken);
+  }
+
+  // TODO - 로그아웃 함수. 로그아웃하면 해당 유저 정보를 delete 리퀘를 보낸다. 어라 로그아웃 api 보내는 곳이 없네...
+  async function logout() {
+    setValues((prev) => ({
+      ...prev,
+      user: null,
+      isPending: false,
+    }));
+  }
+
+  // TODO - 나중에 setting 페이지도 만들 수 있음 만들어보자.
+  // async function updateMe(){}
+
+  return (
+    <AuthContext.Provider
+      value={{ user: values.user, isPending: values.isPending, login, logout }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+// 유저 인증이 필요한 페이지에선 required true 값을 주고,
+// required가 false인데 context.user 값이 없고 로딩 중이 아니라면 로그인 페이지로 이동시킨다.
+export function useAuth(required = "true") {
+  const context = useContext(AuthContext);
+  const router = useRouter();
+  if (!context) {
+    throw new Error("반드시 AuthProvider 안에서 사용해야 합니다.");
+  }
+
+  useEffect(() => {
+    if (required && !context.isPending && !context.user) {
+      router.push("/signin");
+    }
+  }, [context.user, context.isPending, required]);
+
+  return context;
+}

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -117,12 +117,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 export function useAuth(required = "false") {
   const context = useContext(AuthContext);
   const router = useRouter();
+
   if (!context) {
     throw new Error("반드시 AuthProvider 안에서 사용해야 합니다.");
   }
 
   useEffect(() => {
-    if (required && !context.isPending && !context.user) {
+    if (
+      router.route !== "/signup" &&
+      required &&
+      !context.isPending &&
+      !context.user
+    ) {
       router.push("/signin");
     }
   }, [context.user, context.isPending, required]);

--- a/src/hooks/useInputValid.tsx
+++ b/src/hooks/useInputValid.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, useState } from "react";
 import { emailChecker, pswChecker } from "@/utils/checkReg";
 
-const INITIAL_STATE = { hasError: false, errorMsg: "" };
+const INITIAL_ERROR_STATUS = { hasError: false, errorMsg: "" };
 
 const INITIAL_INPUT = {
   email: "",
@@ -10,9 +10,9 @@ const INITIAL_INPUT = {
 };
 
 const INITIAL_ERROR = {
-  email: INITIAL_STATE,
-  password: INITIAL_STATE,
-  passwordRepeat: INITIAL_STATE,
+  email: INITIAL_ERROR_STATUS,
+  password: INITIAL_ERROR_STATUS,
+  passwordRepeat: INITIAL_ERROR_STATUS,
 };
 
 function useInputValid(inputs = "signin") {

--- a/src/hooks/useRequest.tsx
+++ b/src/hooks/useRequest.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect } from "react";
 import { AxiosResponse } from "axios";
 
-export default function useAsync(asyncFunction: () => AxiosResponse) {
+export default function useAsync(asyncFunction: () => Promise<AxiosResponse>) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<unknown>(null);
   const [data, setData] = useState({});

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,48 +1,21 @@
-import { useEffect, useState, useCallback } from "react";
 import type { AppProps } from "next/app";
 import { useRouter } from "next/router";
-import { getUser } from "@/api";
 import { Nav, Footer } from "@/components/common";
-import { UserInterface } from "@/types";
+import { AuthProvider } from "@/contexts/AuthProvider";
 import "@/styles/reset.css";
 import "@/styles/global.scss";
 
 export default function App({ Component, pageProps }: AppProps) {
-  // NOTE - 로컬 스토리지 데이터를 주기적으로 지우는 임시 코드
-  let RESET_LOCAL = setTimeout(() => {
-    if (typeof window !== "undefined" && localStorage.getItem("accessToken")) {
-      localStorage.removeItem("accessToken");
-    }
-  }, 5000);
-
-  const [userValues, setUserValues] = useState<UserInterface>();
   const { route } = useRouter();
-
-  const loadUser = useCallback(async () => {
-    try {
-      const { data } = await getUser();
-      if (!data) return;
-      setUserValues((prevValues) => {
-        return { ...prevValues, ...data[0] };
-      });
-    } catch (e) {
-      return;
-    }
-  }, []);
-
   const hasNav = ["/", "/folder", "/shared"];
-
-  useEffect(() => {
-    loadUser();
-  }, []);
 
   return (
     <>
-      {hasNav.includes(route) && (
-        <Nav profile={userValues} isSticky={route !== "/folder"} />
-      )}
-      <Component {...pageProps} />
-      {hasNav.includes(route) && <Footer />}
+      <AuthProvider>
+        {hasNav.includes(route) && <Nav isSticky={route !== "/folder"} />}
+        <Component {...pageProps} />
+        {hasNav.includes(route) && <Footer />}
+      </AuthProvider>
     </>
   );
 }

--- a/src/pages/folder/index.tsx
+++ b/src/pages/folder/index.tsx
@@ -13,6 +13,7 @@ import { useOpenModal } from "@/hooks";
 import { CardInterface, FolderInterface } from "@/types";
 import styles from "./FolderPage.module.scss";
 import { useAuth } from "@/contexts/AuthProvider";
+import { useRouter } from "next/router";
 
 const INITIAL_FOLDER: FolderInterface = {
   id: "",
@@ -36,7 +37,6 @@ export default function FolderPage() {
 
   const getCards = useCallback(async (currentFolder: FolderInterface) => {
     const data = await getAllCards(user?.id, currentFolder.id);
-    console.log(data);
     if (data) {
       const nextFolder = {
         id: currentFolder.id,

--- a/src/pages/folder/index.tsx
+++ b/src/pages/folder/index.tsx
@@ -12,6 +12,7 @@ import ModalCreator from "@/components/modals/ModalCreator";
 import { useOpenModal } from "@/hooks";
 import { CardInterface, FolderInterface } from "@/types";
 import styles from "./FolderPage.module.scss";
+import { useAuth } from "@/contexts/AuthProvider";
 
 const INITIAL_FOLDER: FolderInterface = {
   id: "",
@@ -26,14 +27,16 @@ export default function FolderPage() {
   const [currentFolder, setCurrentFolder] = useState(INITIAL_FOLDER);
   const { modal, handleOpenModal, handleCloseModal } = useOpenModal();
   const [keyword, setKeyword] = useState("");
+  const { user } = useAuth(true);
 
   const getFolderTagList = useCallback(async () => {
-    const { data } = await getFolderList();
-    setFolderList(() => [INITIAL_FOLDER, ...data]);
+    const { data } = await getFolderList(user?.id);
+    setFolderList(() => [INITIAL_FOLDER, ...data?.folder]);
   }, []);
 
   const getCards = useCallback(async (currentFolder: FolderInterface) => {
-    const data = await getAllCards(currentFolder.id);
+    const data = await getAllCards(user?.id, currentFolder.id);
+    console.log(data);
     if (data) {
       const nextFolder = {
         id: currentFolder.id,

--- a/src/pages/folder/index.tsx
+++ b/src/pages/folder/index.tsx
@@ -53,7 +53,12 @@ export default function FolderPage() {
   }, []);
 
   //TODO - currentFolder을 의존성에 넣으면 무한렌더링 발생. 왜?? 나중에 SSR로 고치기
+  const router = useRouter();
   useEffect(() => {
+    if (!user) {
+      router.push("/signin");
+      return;
+    }
     getFolderTagList();
     getCards(currentFolder);
   }, [getFolderTagList, getCards]);

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -24,8 +24,7 @@ function SignInPage() {
     try {
       await login(emailValue, passwordValue);
       setWrongLogin(false);
-      // TODO - 지금 folderpage로 이동시키면 folder page api 문제로 에러 뜸. 이거 고쳐두기
-      router.push("/");
+      router.push("/folder");
       console.log("login");
     } catch {
       setWrongLogin(true);
@@ -35,8 +34,7 @@ function SignInPage() {
 
   useEffect(() => {
     if (user) {
-      // TODO - 지금 folderpage로 이동시키면 folder page api 문제로 에러 뜸. folder page 코드 고치고 push("/folder") 로 고치기
-      router.push("/");
+      router.push("/folder");
     }
   }, [user]);
 

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -1,9 +1,9 @@
 import { FormEvent, useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import { getSignIn } from "@/api";
 import { Input, SignLayout } from "@/components/sign";
 import { useInputValid } from "@/hooks";
 import styles from "./SignInPage.module.scss";
+import { useAuth } from "@/contexts/AuthProvider";
 
 function SignInPage() {
   const router = useRouter();
@@ -15,28 +15,30 @@ function SignInPage() {
     passwordRepeat: passwordRepeatValue,
   } = inputValue;
 
-  useEffect(() => {
-    if (localStorage.getItem("accessToken")) {
-      router.push("/folder");
-      console.log("login by token");
-    }
-  });
-
+  const { user, login } = useAuth();
   const handleSubmitSignin = async (e: FormEvent) => {
     e.preventDefault();
     if (hasError.email.hasError) {
       return;
     }
-    const signinResponse = await getSignIn(emailValue, passwordValue);
-    if (!signinResponse) {
+    try {
+      await login(emailValue, passwordValue);
+      setWrongLogin(false);
+      // TODO - 지금 folderpage로 이동시키면 folder page api 문제로 에러 뜸. 이거 고쳐두기
+      router.push("/");
+      console.log("login");
+    } catch {
       setWrongLogin(true);
       return;
     }
-    setWrongLogin(false);
-    localStorage.setItem("accessToken", signinResponse.data.accessToken);
-    router.push("/folder");
-    console.log("login");
   };
+
+  useEffect(() => {
+    if (user) {
+      // TODO - 지금 folderpage로 이동시키면 folder page api 문제로 에러 뜸. folder page 코드 고치고 push("/folder") 로 고치기
+      router.push("/");
+    }
+  }, [user]);
 
   return (
     <>

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -33,10 +33,8 @@ function SignUpPage() {
     }
     try {
       const { data } = await getSignUp(emailValue, passwordValue);
-      console.log(data);
       await login(emailValue, passwordValue);
-      router.push("/");
-      // TODO - 지금 folderpage로 이동시키면 folder page api 문제로 에러남... 고쳐야함.
+      router.push("/folder");
     } catch {
       return;
     }

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,9 +1,10 @@
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, useState } from "react";
 import { useRouter } from "next/router";
 import { getSignUp, getEmailCheck } from "@/api";
 import { Input, SignLayout } from "@/components/sign";
 import { useInputValid } from "@/hooks";
 import styles from "./SignUpPage.module.scss";
+import { useAuth } from "@/contexts/AuthProvider";
 
 function SignUpPage() {
   const router = useRouter();
@@ -14,35 +15,30 @@ function SignUpPage() {
     password: passwordValue,
     passwordRepeat: passwordRepeatValue,
   } = inputValue;
-
-  useEffect(() => {
-    if (localStorage.getItem("accessToken")) {
-      router.push("/folder");
-      console.log("signup by token");
-    }
-  });
+  const { user, login } = useAuth();
 
   const handleSubmitSignin = async (e: FormEvent) => {
     e.preventDefault();
-    const emailCheckResponse = await getEmailCheck(emailValue);
-    if (!emailCheckResponse) {
-      // TODO - 공백으로 두고 엔터를 치면 400 에러가 받아와져서 중복된 이메일입니다 메세지가 떠버림 400에러인지 409에러인지에 따라 다르게 처리하는 로직을 짤 것.
-      setIsDuplicated(true);
-      return;
-    }
+    // const emailCheckResponse = await getEmailCheck(emailValue);
+    // BUG - 이메일 체커 api 왜 안돼??? 고쳐야함..
+    // if (!emailCheckResponse) {
+    // TODO - 공백으로 두고 엔터를 치면 400 에러가 받아와져서 중복된 이메일입니다 메세지가 떠버림 400에러인지 409에러인지에 따라 다르게 처리하는 로직을 짤 것.
+    // setIsDuplicated(true);
+    // return;
+    // }
     setIsDuplicated(false);
     if (passwordValue !== passwordRepeatValue) {
       console.log("blocked");
       return;
     }
-    const signupResponse = await getSignUp(emailValue, passwordValue);
-    if (!signupResponse) {
+    try {
+      const { data } = await getSignUp(emailValue, passwordValue);
+      console.log(data);
+      await login(emailValue, passwordValue);
+      router.push("/");
+      // TODO - 지금 folderpage로 이동시키면 folder page api 문제로 에러남... 고쳐야함.
+    } catch {
       return;
-    } else {
-      localStorage.setItem("accessToken", signupResponse.data.accessToken);
-      router.push("/folder");
-      console.log("signup");
-      console.log(signupResponse);
     }
   };
 

--- a/src/utils/calcDate.tsx
+++ b/src/utils/calcDate.tsx
@@ -11,7 +11,7 @@ function calcDate(value: string = "") {
     return "";
   };
 
-  let minute: number = (now.getTime() - +createdDate) / 1000 / 60;
+  let minute: number = (now.getTime() - createdDate.getTime()) / 1000 / 60;
   let str = helpCalc(minute, 60, "minute");
   if (str) return str;
 


### PR DESCRIPTION
## 요구사항

### 기본

- [ ] [링크 공유 페이지] 링크 공유 페이지의 url path를 ‘/shared’에서 ‘/shared/{folderId}’로 변경했나요?
- [ ] [링크 공유 페이지] 폴더의 정보는 ‘/api/folders/{folderId}’, 폴더 소유자의 정보는 ‘/api/users/{userId}’를 활용했나요?
- [ ] [링크 공유 페이지] 링크 공유 페이지에서 폴더의 링크 데이터는 ‘/api/users/{userId}/links?folderId={folderId}’를 사용했나요?

- [x] [폴더 페이지] 폴더 페이지에서 유저가 access token이 없는 경우 ‘/signin’페이지로 이동하나요?
- [x] [폴더 페이지] 폴더 페이지의 url path가 ‘/folder’일 경우 폴더 목록에서 “전체” 가 선택되어 있고, ‘/folder/{folderId}’일 경우 폴더 목록에서 {folderId} 에 해당하는 폴더가 선택되어 있고 폴더에 있는 링크들을 볼 수 있나요?
- [x] [폴더 페이지] 폴더 페이지에서 현재 유저의 폴더 목록 데이터를 받아올 때 ‘/api/folders’를 활용했나요?
- [x] [폴더 페이지] 폴더 페이지에서 전체 링크 데이터를 받아올 때 ‘/api/links’, 특정 폴더의 링크를 받아올 때 ‘/api/links?folderId=1’를 활용했나요?

- [x] [상단  네비게이션] 유효한 access token이 있는 경우 ‘/api/users’로 현재 로그인한 유저 정보를 받아 상단 네비게이션 유저 프로필을 보여주나요?

- [x] [심화] 리퀘스트 헤더에 인증 토큰을 첨부할 때 axios interceptors 또는 이와 유사한 기능을 활용 했나요?


## 주요 변경사항

-
-

## 스크린샷

![image](이미지url)

## 멘토에게

- 고칠 부분이 진짜 많습니다...!!! 
-  1. 아직 use input form을 사용 못해봤습니다 ㅠㅠ 금방 코드 고쳐보겠습니다.
-  2. 아직 shared 페이지는 시간이 없어서 못 건드렸습니다.. ㅠㅠ 죄송합니다 금방 고치겠습니다,
-  3. useAuth 함수 타입에 자꾸 에러가 나서 다 any 타입으로 정했는데.. 이것도 고쳐보겠습니다..!! ㅠㅠ
 
####  질문할 부분
- ~~ _1.  토큰을 사용하기 위해 response로 accesstoken과 refreshToken을 받으면 일단 localStorage에 저장되게 하고, logout 버튼을 누르면 localStorage의 토큰들이 삭제되게 했습니다. 그런데 logout 이후 /folder 페이지로 이동하면 login 페이지로 리다이렉트 되지 않고 에러가 나는데, 왜 그런건지 모르겠습니다._~~ >> (23.12.18) 왜 이런 에러가 나는진 알겠는데 어떻게 고쳐야 할지 모르겠습니다. 해당 부분 코멘트로 달아두겠습니다 ㅠㅠ !! 
-  2.  지금은 토큰을 저장하기 위해 localStorage를 썼는데, 다른 좋은 방법이 있을까요??
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
